### PR TITLE
Withdrawals to return ready as well as pending withdrawals

### DIFF
--- a/src/api/contract/getStarkKey.js
+++ b/src/api/contract/getStarkKey.js
@@ -5,14 +5,14 @@ module.exports = async dvf => {
   const ethAddress = dvf.get('account')
   const args = [ethAddress]
   try {
-    const sarkKeyDecimal = await dvf.eth.call(
+    const starkKeyDecimal = await dvf.eth.call(
       dvf.contract.abi.StarkEx,
       dvf.config.DVF.starkExContractAddress,
       'getStarkKey',
       args
     )
 
-    return new BN(sarkKeyDecimal).toString(16)
+    return new BN(starkKeyDecimal).toString(16)
   } catch (e) {
     console.log('contract/getStarkKey error is: ', e)
     throw new DVFError('ERR_GETTING_STARK_KEY')

--- a/src/api/contract/getStarkKey.js
+++ b/src/api/contract/getStarkKey.js
@@ -1,0 +1,20 @@
+const DVFError = require('../../lib/dvf/DVFError')
+const BN = require('bignumber.js')
+
+module.exports = async dvf => {
+  const ethAddress = dvf.get('account')
+  const args = [ethAddress]
+  try {
+    const sarkKeyDecimal = await dvf.eth.call(
+      dvf.contract.abi.StarkEx,
+      dvf.config.DVF.starkExContractAddress,
+      'getStarkKey',
+      args
+    )
+
+    return new BN(sarkKeyDecimal).toString(16)
+  } catch (e) {
+    console.log('contract/getStarkKey error is: ', e)
+    throw new DVFError('ERR_GETTING_STARK_KEY')
+  }
+}

--- a/src/api/contract/getWithdrawalBalance.js
+++ b/src/api/contract/getWithdrawalBalance.js
@@ -1,0 +1,20 @@
+const DVFError = require('../../lib/dvf/DVFError')
+const BN = require('bignumber.js')
+
+module.exports = async (dvf, token) => {
+  const starkKey = await dvf.contract.getStarkKey()
+  const starkTokenId = dvf.config.tokenRegistry[token].starkTokenId
+  const args = ['0x' + starkKey, starkTokenId]
+
+  try {
+    return (withdrawalBalance = await dvf.eth.call(
+      dvf.contract.abi.StarkEx,
+      dvf.config.DVF.starkExContractAddress,
+      'getWithdrawalBalance',
+      args
+    ))
+  } catch (e) {
+    console.log('contract/getStarkKey error is: ', e)
+    throw new DVFError('ERR_GETTING_AVAILABLE_WITHDRAWAL')
+  }
+}

--- a/src/api/getWithdrawals.js
+++ b/src/api/getWithdrawals.js
@@ -6,7 +6,7 @@ module.exports = async (dvf, token, nonce, signature) => {
     validateAssertions(dvf, { token })
   }
 
-  const endpoint = '/v1/trading/r/getWithdrawals'
+  const endpoint = '/v1/trading/r/getPendingWithdrawals'
 
   const data = { token }
 

--- a/src/api/getWithdrawals.js
+++ b/src/api/getWithdrawals.js
@@ -10,5 +10,24 @@ module.exports = async (dvf, token, nonce, signature) => {
 
   const data = { token }
 
-  return post(dvf, endpoint, nonce, signature, data)
+  const withdrawals = await post(dvf, endpoint, nonce, signature, data)
+
+  for (const key in dvf.config.tokenRegistry) {
+    const available = await dvf.contract.getWithdrawalBalance(key)
+
+    if (parseInt(available) > 0) {
+      const amount = dvf.token.toBaseUnitAmount(
+        key,
+        dvf.token.fromQuantizedAmount(key, available)
+      )
+
+      withdrawals.push({
+        token: key,
+        status: 'ready',
+        amount
+      })
+    }
+  }
+
+  return withdrawals
 }

--- a/src/api/getWithdrawals.test.js
+++ b/src/api/getWithdrawals.test.js
@@ -43,7 +43,7 @@ describe('dvf.getWithdrawals', () => {
     })
 
     nock(dvf.config.api)
-      .post('/v1/trading/r/getWithdrawals', payloadValidator)
+      .post('/v1/trading/r/getPendingWithdrawals', payloadValidator)
       .reply(200, apiResponse)
 
     const result = await dvf.getWithdrawals()
@@ -83,7 +83,7 @@ describe('dvf.getWithdrawals', () => {
     })
 
     nock(dvf.config.api)
-      .post('/v1/trading/r/getWithdrawals', payloadValidator)
+      .post('/v1/trading/r/getPendingWithdrawals', payloadValidator)
       .reply(200, apiResponse)
 
     const result = await dvf.getWithdrawals(token, nonce, signature)
@@ -105,7 +105,7 @@ describe('dvf.getWithdrawals', () => {
     })
 
     nock(dvf.config.api)
-      .post('/v1/trading/r/getWithdrawals', payloadValidator)
+      .post('/v1/trading/r/getPendingWithdrawals', payloadValidator)
       .reply(200, apiResponse)
 
     const result = await dvf.getWithdrawals(token)
@@ -132,7 +132,7 @@ describe('dvf.getWithdrawals', () => {
     const payloadValidator = jest.fn(() => true)
 
     nock(dvf.config.api)
-      .post('/v1/trading/r/getWithdrawals', payloadValidator)
+      .post('/v1/trading/r/getPendingWithdrawals', payloadValidator)
       .reply(422, apiErrorResponse)
 
     try {

--- a/src/api/getWithdrawals.test.js
+++ b/src/api/getWithdrawals.test.js
@@ -12,8 +12,27 @@ describe('dvf.getWithdrawals', () => {
     dvf = await instance()
   })
 
-  it(`Query for all withdrawals`, async () => {
-    const apiResponse = []
+  it(`Query withdrawals for all tokens`, async () => {
+    const apiResponse = [
+      {
+        token: 'ETH',
+        amount: 1000000
+      },
+      {
+        token: 'USDT',
+        amount: 2000000
+      },
+      {
+        token: 'USDT',
+        status: 'ready',
+        amount: 5000000
+      },
+      {
+        token: 'ZRX',
+        status: 'ready',
+        amount: 25000000
+      }
+    ]
 
     const payloadValidator = jest.fn(body => {
       expect(typeof body.nonce).toBe('number')
@@ -34,12 +53,26 @@ describe('dvf.getWithdrawals', () => {
     expect(result).toEqual(apiResponse)
   })
 
-  it(`Query for withdrawals for a given token`, async () => {
+  it(`Query withdrawals for a specified token`, async () => {
     const nonce = Date.now() / 1000 + ''
     const signature = await dvf.sign(nonce.toString(16))
     const token = 'ETH'
 
-    const apiResponse = []
+    const apiResponse = [
+      {
+        token: 'ETH',
+        amount: 1000000
+      },
+      {
+        token: 'ETH',
+        amount: 2000000
+      },
+      {
+        token: 'ETH',
+        status: 'ready',
+        amount: 5000000
+      }
+    ]
 
     const payloadValidator = jest.fn(body => {
       expect(body.nonce).toEqual(nonce)

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -38,6 +38,10 @@ module.exports = () => {
     approve: compose(require('../../api/contract/approve')),
     isApproved: compose(require('../../api/contract/isApproved')),
     deposit: compose(require('../../api/contract/deposit')),
+    getStarkKey: compose(require('../../api/contract/getStarkKey')),
+    getWithdrawalBalance: compose(
+      require('../../api/contract/getWithdrawalBalance')
+    ),
     withdraw: compose(require('../../api/contract/withdraw')),
     abi: {
       token: require('../../api/contract/abi/token.abi'),


### PR DESCRIPTION
This updates getWithdrawals to return withdrawal requests which are ready as well as the ones which are not ready.
The withdrawal requests which are ready will show a total amount available for withdrawal clubbed together by token.
The withdrawal requests which are not ready will show individual withdrawal requests which have been made by the user(eg. ETH 1, ETH 5, ETH 9)
