### PR TITLE
test helpers, submitOrderNew, improved createOrderMetaData, getVaultId

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "@ledgerhq/hw-transport-webhid": "^5.12.0",
     "@ledgerhq/hw-transport-webusb": "^5.12.0",
     "@ledgerhq/web3-subprovider": "^5.12.2",
+    "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^7.2.1",
-    "bluebird": "^3.5.1",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",
@@ -60,7 +60,6 @@
     "web3-provider-engine": "^15.0.6"
   },
   "devDependencies": {
-    "aigle": "^1.14.1",
     "browser-run": "^5.0.0",
     "browserify": "^16.2.2",
     "del": "^3.0.0",

--- a/src/api/getVaultId.js
+++ b/src/api/getVaultId.js
@@ -8,9 +8,6 @@ module.exports = async (dvf, token, nonce, signature) => {
     return existingVaultId
   }
   else {
-    const endpoint = '/v1/trading/r/getVaultId'
-    const data = { token }
-
     const vaultId = await dvf.getVaultIdFromServer(token, nonce, signature)
 
     dvf.config.tokenRegistry[token].starkVaultId = vaultId

--- a/src/api/getVaultId.js
+++ b/src/api/getVaultId.js
@@ -1,0 +1,20 @@
+const validateAssertions = require('../lib/validators/validateAssertions')
+
+module.exports = async (dvf, token, nonce, signature) => {
+  validateAssertions(dvf, {token})
+
+  const existingVaultId = dvf.config.tokenRegistry[token].starkVaultId
+  if (existingVaultId != null) {
+    return existingVaultId
+  }
+  else {
+    const endpoint = '/v1/trading/r/getVaultId'
+    const data = { token }
+
+    const vaultId = await dvf.getVaultIdFromServer(token, nonce, signature)
+
+    dvf.config.tokenRegistry[token].starkVaultId = vaultId
+
+    return vaultId
+  }
+}

--- a/src/api/getVaultIdFromServer.js
+++ b/src/api/getVaultIdFromServer.js
@@ -1,0 +1,8 @@
+const validateAssertions = require('../lib/validators/validateAssertions')
+
+module.exports = (dvf, token, nonce, signature) => dvf.postAuthenticated(
+  '/v1/trading/r/getVaultId',
+  nonce,
+  signature,
+  { token }
+)

--- a/src/api/submitOrderNew.js
+++ b/src/api/submitOrderNew.js
@@ -1,14 +1,7 @@
-const { post } = require('request-promise')
+const rp = require('request-promise')
 
 // TODO: define a schema for data and validate it.
-module.exports = async (dvf, data) => {
-  const payload = await dvf.createOrderPayload(data)
-
-  const url = dvf.config.api + '/v1/trading/w/submitOrder'
-
-  const submitResponse = await post(url, { json: payload })
-
-  await dvf.getUserConfig()
-
-  return submitResponse
+module.exports = async (dvf, data) => rp.post(
+  dvf.config.api + '/v1/trading/w/submitOrder',
+  { json: await dvf.createOrderPayload(data) }
 }

--- a/src/api/submitOrderNew.js
+++ b/src/api/submitOrderNew.js
@@ -1,0 +1,14 @@
+const { post } = require('request-promise')
+
+// TODO: define a schema for data and validate it.
+module.exports = async (dvf, data) => {
+  const payload = await dvf.createOrderPayload(data)
+
+  const url = dvf.config.api + '/v1/trading/w/submitOrder'
+
+  const submitResponse = await post(url, { json: payload })
+
+  await dvf.getUserConfig()
+
+  return submitResponse
+}

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,9 @@ module.exports = {
   // default account to select in case no account is provided by the userConfig
   // parameter
   account: 0,
+  // selects account from web3 provider based on config.account upon
+  // initialization
+  autoSelectAccount: true,
 
   // enables integrators to select if they want to fetch user config upon initialization
   autoLoadUserConf: true

--- a/src/dvf.js
+++ b/src/dvf.js
@@ -51,10 +51,13 @@ module.exports = async (web3, userConfig = {}) => {
 
   // REVIEW: should we actually use web3.eth.defaultAccount ?
   // see: https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#raising_hand-account-list-reflects-user-preference
-  await dvf.account.select(dvf.config.account)
 
-  if (!dvf.get('account')) {
-    console.warn('Please specify a valid account or account index')
+  if (dvf.config.autoSelectAccount) {
+    await dvf.account.select(dvf.config.account)
+
+    if (!dvf.get('account')) {
+      console.warn('Please specify a valid account or account index')
+    }
   }
 
   // get user config once we get the Web3 provider and Eth Address

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -92,6 +92,8 @@ module.exports = () => {
   dvf.sign.request = compose(require('../../api/sign/request'))
   dvf.sign.nonceSignature = compose(require('../../api/sign/nonceSignature'))
 
+  dvf.postAuthenticated = compose(require('../../lib/dvf/post-authenticated'))
+
   dvf.createOrderPayload = compose(require('../../lib/dvf/createOrderPayload'))
   dvf.createOrderMetaData = compose(require('../../lib/dvf/createOrderMetaData'))
 
@@ -108,6 +110,8 @@ module.exports = () => {
   dvf.getOrders = compose(require('../../api/getOrders'))
   dvf.getOrdersHist = compose(require('../../api/getOrdersHist'))
   dvf.getUserConfig = compose(require('../../api/getUserConfig'))
+  dvf.getVaultId = compose(require('../../api/getVaultId'))
+  dvf.getVaultIdFromServer = compose(require('../../api/getVaultIdFromServer'))
   dvf.preRegister = compose(require('../../api/preRegister'))
   dvf.register = compose(require('../../api/register'))
   dvf.submitBuyOrder = compose(require('../../api/submitBuyOrder'))

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -92,6 +92,9 @@ module.exports = () => {
   dvf.sign.request = compose(require('../../api/sign/request'))
   dvf.sign.nonceSignature = compose(require('../../api/sign/nonceSignature'))
 
+  dvf.createOrderPayload = compose(require('../../lib/dvf/createOrderPayload'))
+  dvf.createOrderMetaData = compose(require('../../lib/dvf/createOrderMetaData'))
+
   // dvf main functions
   dvf.cancelOrder = compose(require('../../api/cancelOrder'))
   dvf.deposit = compose(require('../../api/deposit'))

--- a/src/lib/dvf/createOrderMetaData.js
+++ b/src/lib/dvf/createOrderMetaData.js
@@ -1,0 +1,53 @@
+const validateProps = require('../validators/validateProps')
+const validateAssertions = require('../validators/validateAssertions')
+
+const starkSignedOrder = async (
+  dvf,
+  starkPrivateKey,
+  starkMessage
+) => {
+  validateAssertions(dvf, {starkPrivateKey})
+
+  const { starkKeyPair, starkPublicKey } = await dvf.stark.createKeyPair(
+    starkPrivateKey
+  )
+
+  const starkSignature = dvf.stark.sign(starkKeyPair, starkMessage)
+
+  return {
+    starkPublicKey,
+    starkSignature
+  }
+}
+
+module.exports = async (
+  dvf,
+  orderData
+) => {
+  validateProps(dvf, ['amount', 'symbol', 'price'], orderData)
+
+  // TODO: refactor createOrder to accept orderData
+  const { starkOrder, starkMessage } = dvf.stark.createOrder(
+    orderData.symbol,
+    orderData.amount,
+    orderData.price,
+    orderData.validFor,
+    orderData.feeRate
+  )
+
+  const {
+    starkPublicKey,
+    starkSignature
+  } = await (orderData.ledgerPath ?
+    dvf.stark.ledger.createSignedOrder(path, starkOrder)
+    :
+    starkSignedOrder(dvf, orderData.starkPrivateKey, starkMessage)
+  )
+
+  return {
+    starkPublicKey,
+    starkOrder,
+    starkMessage,
+    starkSignature
+  }
+}

--- a/src/lib/dvf/createOrderMetaData.js
+++ b/src/lib/dvf/createOrderMetaData.js
@@ -26,14 +26,7 @@ module.exports = async (
 ) => {
   validateProps(dvf, ['amount', 'symbol', 'price'], orderData)
 
-  // TODO: refactor createOrder to accept orderData
-  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
-    orderData.symbol,
-    orderData.amount,
-    orderData.price,
-    orderData.validFor,
-    orderData.feeRate
-  )
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder(orderData)
 
   const {
     starkPublicKey,

--- a/src/lib/dvf/createOrderMetaData.js
+++ b/src/lib/dvf/createOrderMetaData.js
@@ -27,7 +27,7 @@ module.exports = async (
   validateProps(dvf, ['amount', 'symbol', 'price'], orderData)
 
   // TODO: refactor createOrder to accept orderData
-  const { starkOrder, starkMessage } = dvf.stark.createOrder(
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
     orderData.symbol,
     orderData.amount,
     orderData.price,

--- a/src/lib/dvf/createOrderPayload.js
+++ b/src/lib/dvf/createOrderPayload.js
@@ -1,0 +1,32 @@
+const FP = require('lodash/fp')
+
+// TODO: define a schema for data.
+// Default (like the type, protocol, feeRate below) can  go on that schema.
+module.exports = async (dvf, data) => {
+  // allow passing in ethAddress (useful for testing).
+  const ethAddress = data.ethAddress || dvf.get('account')
+
+  return {
+    type: 'EXCHANGE LIMIT',
+    protocol: 'stark',
+    feeRate: 0.0025,
+    ...(
+      FP.pick([
+          'amount',
+          'cid',
+          'dynamicFeeRate',
+          'feeRate',
+          'gid',
+          'partnerId',
+          'price',
+          'symbol',
+        ],
+        data
+      )
+    ),
+    meta: {
+      ethAddress,
+      ...(await dvf.createOrderMetaData(data))
+    }
+  }
+}

--- a/src/lib/stark/createKeyPair.js
+++ b/src/lib/stark/createKeyPair.js
@@ -19,8 +19,9 @@ module.exports = (privateKey) => {
       x: fullPublicKey.pub.getX().toString('hex'),
       y: fullPublicKey.pub.getY().toString('hex')
     }
+    const starkPrivateKey = privateKey
 
-    return {privateKey, starkKeyPair, starkPublicKey}
+    return {privateKey, starkPrivateKey, starkKeyPair, starkPublicKey}
   } catch (e) {
     return {
       error: 'ERR_PUBLICKEY_CREATION',

--- a/src/lib/stark/createKeyPair.js
+++ b/src/lib/stark/createKeyPair.js
@@ -3,13 +3,13 @@ const createPrivateKey = require('./createPrivateKey')
 const errorReasons = require('../dvf/DVFError')
 
 // QUESTION: remove async from function and make privateKey mandatory?
-module.exports = (privateKey) => {
-  if (!privateKey) {
-    privateKey = createPrivateKey()
+module.exports = (starkPrivateKey) => {
+  if (!starkPrivateKey) {
+    starkPrivateKey = createPrivateKey()
   }
 
   try {
-    const starkKeyPair = sw.ec.keyFromPrivate(privateKey, 'hex')
+    const starkKeyPair = sw.ec.keyFromPrivate(starkPrivateKey, 'hex')
 
     const fullPublicKey = sw.ec.keyFromPublic(
       starkKeyPair.getPublic(true, 'hex'),
@@ -19,9 +19,8 @@ module.exports = (privateKey) => {
       x: fullPublicKey.pub.getX().toString('hex'),
       y: fullPublicKey.pub.getY().toString('hex')
     }
-    const starkPrivateKey = privateKey
 
-    return {privateKey, starkPrivateKey, starkKeyPair, starkPublicKey}
+    return {starkPrivateKey, starkKeyPair, starkPublicKey}
   } catch (e) {
     return {
       error: 'ERR_PUBLICKEY_CREATION',

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -1,7 +1,8 @@
+const P = require('aigle')
 const BigNumber = require('bignumber.js')
 const DVFError = require('../dvf/DVFError')
 
-module.exports = (dvf, symbol, amount, price, validFor, feeRate = 0.0025) => {
+module.exports = async (dvf, symbol, amount, price, validFor, feeRate = 0.0025) => {
   // symbols are always 3 letters
   const baseSymbol = symbol.split(':')[0]
   const quoteSymbol = symbol.split(':')[1]
@@ -11,21 +12,15 @@ module.exports = (dvf, symbol, amount, price, validFor, feeRate = 0.0025) => {
 
   const sellCurrency = dvf.token.getTokenInfo(sellSymbol)
   const buyCurrency = dvf.token.getTokenInfo(buySymbol)
-  const vaultIdSell = sellCurrency.starkVaultId
+
+  const [ vaultIdSell, vaultIdBuy ] = await P.join(
+    dvf.getVaultId(sellSymbol),
+    dvf.getVaultId(buySymbol)
+  )
 
   // console.log("sell :", sellSymbol, sellCurrency)
   // console.log("buy  :", buySymbol, buyCurrency)
 
-  if (!vaultIdSell) {
-    console.error('No token vault for :', sellSymbol)
-
-    throw new DVFError('ERR_NO_TOKEN_VAULT')
-  }
-
-  let vaultIdBuy = buyCurrency.starkVaultId
-  if (!vaultIdBuy) {
-    vaultIdBuy = dvf.config.spareStarkVaultId
-  }
 
   if (!(sellCurrency && buyCurrency)) {
     if (!vaultIdSell) {

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -2,7 +2,10 @@ const P = require('aigle')
 const BigNumber = require('bignumber.js')
 const DVFError = require('../dvf/DVFError')
 
-module.exports = async (dvf, symbol, amount, price, validFor, feeRate = 0.0025) => {
+module.exports = async (
+  dvf,
+  { symbol, amount, price, validFor, feeRate = 0.0025}
+) => {
   // symbols are always 3 letters
   const baseSymbol = symbol.split(':')[0]
   const quoteSymbol = symbol.split(':')[1]

--- a/src/lib/stark/createOrderMessage.js
+++ b/src/lib/stark/createOrderMessage.js
@@ -15,6 +15,7 @@ module.exports = starkOrder => {
     )
     return message
   } catch (err) {
+    console.error('ERR_CREATING_STARK_ORDER_MESSAGE: error', err)
     throw new DVFError('ERR_CREATING_STARK_ORDER_MESSAGE')
   }
 }

--- a/src/lib/stark/createOrderMetaData.js
+++ b/src/lib/stark/createOrderMetaData.js
@@ -1,5 +1,3 @@
-const BigNumber = require('bignumber.js')
-const DVFError = require('../dvf/DVFError')
 const validAssertions = require('../validators/validateAssertions')
 
 module.exports = async (

--- a/src/lib/stark/createOrderMetaData.js
+++ b/src/lib/stark/createOrderMetaData.js
@@ -11,13 +11,13 @@ module.exports = async (
 ) => {
   validAssertions(dvf, { amount, symbol, price, starkPrivateKey })
 
-  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder({
     symbol,
     amount,
     price,
     validFor,
     feeRate
-  )
+  })
 
   const { starkKeyPair, starkPublicKey } = await dvf.stark.createKeyPair(
     starkPrivateKey

--- a/src/lib/stark/createOrderMetaData.js
+++ b/src/lib/stark/createOrderMetaData.js
@@ -11,7 +11,7 @@ module.exports = async (
 ) => {
   validAssertions(dvf, { amount, symbol, price, starkPrivateKey })
 
-  const { starkOrder, starkMessage } = dvf.stark.createOrder(
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
     symbol,
     amount,
     price,

--- a/src/lib/stark/ledger/createOrderMetaData.js
+++ b/src/lib/stark/ledger/createOrderMetaData.js
@@ -11,7 +11,7 @@ module.exports = async (
 ) => {
   validAssertions(dvf, { amount, symbol, price })
 
-  const { starkOrder, starkMessage } = dvf.stark.createOrder(
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
     symbol,
     amount,
     price,

--- a/src/lib/stark/ledger/createOrderMetaData.js
+++ b/src/lib/stark/ledger/createOrderMetaData.js
@@ -11,13 +11,13 @@ module.exports = async (
 ) => {
   validAssertions(dvf, { amount, symbol, price })
 
-  const { starkOrder, starkMessage } = await dvf.stark.createOrder(
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder({
     symbol,
     amount,
     price,
     validFor,
     feeRate
-  )
+  })
 
   const {
     starkPublicKey,

--- a/src/lib/validators/validateProps.js
+++ b/src/lib/validators/validateProps.js
@@ -1,0 +1,23 @@
+const FP = require('lodash/fp')
+const validateAssertions = require('./validateAssertions')
+
+const validators = {
+  orderId: require('./orderId'),
+  symbol: require('./symbol'),
+  token: require('./token'),
+  nonce: require('./nonce'),
+  signature: require('./deFiSignature'),
+  amount: require('./amount'),
+  price: require('./price'),
+  starkPublicKey: require('./starkPublicKey'),
+  starkKeyPair: require('./starkKeyPair'),
+  ethAddress: require('./ethAddress'),
+  deFiSignature: require('./deFiSignature'),
+  starkPrivateKey: require('./starkPrivateKey'),
+  withdrawalId: require('./withdrawalId')
+}
+
+module.exports = (dvf, props, obj) => validateAssertions(
+  dvf,
+  FP.pick(props, obj)
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,7 +1400,7 @@ bl@^4.0.1:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.5.0, bluebird@^3.5.1:
+bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==


### PR DESCRIPTION
this PR contains:
- changes which are meant to facilitate testing of stark-trading
- proposed improvement to implementation and interface of submitOrder
- getVaultId api method which is used to retrieve vault id for user/token
  on demand, instead of relying on spareStarkVaultId