### PR TITLE
getVaultId for new token deposit

### DIFF
--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -12,10 +12,8 @@ module.exports = async (dvf, token, amount, starkPrivateKey) => {
   const tempVaultId = dvf.config.DVF.tempStarkVaultId
   const nonce = dvf.util.generateRandomNonce()
   const starkTokenId = currency.starkTokenId
-  let starkVaultId = currency.starkVaultId
-  if (!starkVaultId) {
-    starkVaultId = dvf.config.spareStarkVaultId
-  }
+  const starkVaultId = await dvf.getVaultId(token)
+  console.log({ starkVaultId })
   const { starkPublicKey, starkKeyPair } = await dvf.stark.createKeyPair(
     starkPrivateKey
   )

--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -13,7 +13,7 @@ module.exports = async (dvf, token, amount, starkPrivateKey) => {
   const nonce = dvf.util.generateRandomNonce()
   const starkTokenId = currency.starkTokenId
   const starkVaultId = await dvf.getVaultId(token)
-  console.log({ starkVaultId })
+
   const { starkPublicKey, starkKeyPair } = await dvf.stark.createKeyPair(
     starkPrivateKey
   )
@@ -54,8 +54,6 @@ module.exports = async (dvf, token, amount, starkPrivateKey) => {
   if (!status) {
     throw new DVFError('ERR_ONCHAIN_DEPOSIT')
   }
-
-  await dvf.getUserConfig()
 
   return depositResponse
 }


### PR DESCRIPTION
Using `getVaultId()` Pub API call to retrieve new vault id for depositing a new token and assigning a new stark vault id.

There is no need to call getUserConfig at the end of deposit as a new Vault Id is already updated in dvf.config by `getVaultId()`.