### PR TITLE
Order Price and Amount Precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "0.1.0",
+  "version": "0.1.7",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",

--- a/src/api/getConfig.test.js
+++ b/src/api/getConfig.test.js
@@ -32,7 +32,7 @@ describe('dvf.getConfig', () => {
           decimals: 6,
           quantization: 1,
           minOrderSize: 25,
-          settleSpread: -0.026,
+          settleSpread: 0,
           starkTokenId:
             '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
           tokenAddress: '0x4c5f66596197a86fb30a2435e2ef4ddcb39342c9'

--- a/src/api/getUserConfig.test.js
+++ b/src/api/getUserConfig.test.js
@@ -33,7 +33,7 @@ describe('dvf.getUserConfig', () => {
           decimals: 6,
           quantization: 1,
           minOrderSize: 25,
-          settleSpread: -0.026,
+          settleSpread: 0,
           starkTokenId:
             '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
           tokenAddress: '0x4c5f66596197a86fb30a2435e2ef4ddcb39342c9',

--- a/src/api/test/fixtures/getConf.js
+++ b/src/api/test/fixtures/getConf.js
@@ -21,7 +21,7 @@ module.exports = () => {
         decimals: 6,
         quantization: 1,
         minOrderSize: 25,
-        settleSpread: -0.026,
+        settleSpread: 0,
         starkTokenId:
           '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
         tokenAddress: '0x4c5f66596197a86fb30a2435e2ef4ddcb39342c9'
@@ -71,7 +71,7 @@ module.exports = () => {
         decimals: 6,
         quantization: 1,
         minOrderSize: 25,
-        settleSpread: -0.026,
+        settleSpread: 0,
         starkTokenId:
           '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
         tokenAddress: '0x4c5f66596197a86fb30a2435e2ef4ddcb39342c9',

--- a/src/lib/dvf/computeBuySellDats.js
+++ b/src/lib/dvf/computeBuySellDats.js
@@ -1,0 +1,51 @@
+const BN = require('./token/BN')
+const splitSymbol = require('./token/splitSymbol')
+
+module.exports = (dvf, { symbol, amount, price, feeRate }) => {
+  if (amount == 0) throw new Error('amount cannot be 0')
+  if (price <= 0) throw new Error('price has to be greater than 0')
+
+  const [ baseToken, quoteToken ] = splitSymbol(symbol)
+  const absAmount = Math.abs(amount)
+
+  const base = {
+    token: baseToken,
+    amount: absAmount
+  }
+
+  const quote = {
+    token: quoteToken,
+    amount: absAmount * price
+  }
+
+  const [ buy, sell ] = amount > 0
+    ? [ base, quote ]
+    : [ quote, base ]
+
+  const sellTokenReg = dvf.token.getTokenInfo(sell.token)
+  const buyTokenReg = dvf.token.getTokenInfo(buy.token)
+  console.log({sellTokenReg, buyTokenReg})
+  const amountBuy = BN(10)
+    .pow(buyTokenReg.decimals)
+    .times(buy.amount)
+    .dividedBy(buyTokenReg.quantization)
+    .times(1 + (buyTokenReg.settleSpread || 0))
+    .times(1 - feeRate)
+    .integerValue()
+    .toString()
+
+  const amountSell = BN(10)
+    .pow(sellTokenReg.decimals)
+    .times(sell.amount)
+    .dividedBy(sellTokenReg.quantization)
+    .times(1 + (sellTokenReg.settleSpread || 0))
+    .integerValue()
+    .toString()
+
+  return {
+    amountSell,
+    amountBuy,
+    tokenSell: sell.token,
+    tokenBuy: buy.token
+  }
+}

--- a/src/lib/dvf/token/BN.js
+++ b/src/lib/dvf/token/BN.js
@@ -1,0 +1,10 @@
+const BigNumber = require('bignumber.js')
+
+BigNumber.config({ 
+  DECIMAL_PLACES: 50,
+  ROUNDING_MODE: BigNumber.ROUND_HALF_UP 
+})
+
+module.exports = (number) => {
+  return new BigNumber(number)
+}

--- a/src/lib/dvf/token/getTokenInfo.js
+++ b/src/lib/dvf/token/getTokenInfo.js
@@ -1,3 +1,7 @@
 module.exports = (dvf, token) => {
+  if (token === 'USD') {
+    token = 'USDT'
+  }
+  
   return dvf.config.tokenRegistry[token]
 }

--- a/src/lib/dvf/token/splitSymbol.js
+++ b/src/lib/dvf/token/splitSymbol.js
@@ -1,0 +1,1 @@
+module.exports = symbol => symbol.split(':')

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -1,76 +1,36 @@
 const P = require('aigle')
-const BigNumber = require('bignumber.js')
 const DVFError = require('../dvf/DVFError')
+const computeBuySellData = require('../dvf/computeBuySellDats')
 
 module.exports = async (dvf, { symbol, amount, price, validFor, feeRate }) => {
   feeRate = parseFloat(feeRate) || dvf.config.DVF.defaultFeeRate
   // symbols are always 3 letters
   const baseSymbol = symbol.split(':')[0]
   const quoteSymbol = symbol.split(':')[1]
-
+  
   const buySymbol = amount > 0 ? baseSymbol : quoteSymbol
   const sellSymbol = amount > 0 ? quoteSymbol : baseSymbol
-
+  
   const sellCurrency = dvf.token.getTokenInfo(sellSymbol)
   const buyCurrency = dvf.token.getTokenInfo(buySymbol)
-
+  
   const [vaultIdSell, vaultIdBuy] = await P.join(
     dvf.getVaultId(sellSymbol),
     dvf.getVaultId(buySymbol)
   )
-
-  // console.log('sell :', sellSymbol, sellCurrency)
-  // console.log('buy  :', buySymbol, buyCurrency)
-
   if (!(sellCurrency && buyCurrency)) {
     if (!vaultIdSell) {
       throw new DVFError('ERR_SYMBOL_DOES_NOT_MATCH')
     }
   }
 
-  let buyAmount, sellAmount
+  const {
+    amountSell,
+    amountBuy
+  } = computeBuySellData(dvf,{ symbol, amount, price, feeRate })
 
-  if (amount > 0) {
-    buyAmount = new BigNumber(10)
-      .pow(buyCurrency.decimals)
-      .times(amount)
-      .dividedBy(buyCurrency.quantization)
-      .times(1 + (buyCurrency.settleSpread || 0))
-      .times(1 - feeRate)
-      .integerValue(BigNumber.ROUND_CIEL)
-      .abs()
-      .toString()
-    sellAmount = new BigNumber(10)
-      .pow(sellCurrency.decimals)
-      .times(amount)
-      .dividedBy(sellCurrency.quantization)
-      .times(price)
-      .times(1 + (sellCurrency.settleSpread || 0))
-      .integerValue(BigNumber.ROUND_FLOOR)
-      .abs()
-      .toString()
-  }
-
-  if (amount < 0) {
-    buyAmount = new BigNumber(10)
-      .pow(buyCurrency.decimals)
-      .dividedBy(buyCurrency.quantization)
-      .times(amount)
-      .times(price)
-      .times(1 + (buyCurrency.settleSpread || 0))
-      .times(1 - feeRate)
-      .integerValue(BigNumber.ROUND_CIEL)
-      .abs()
-      .toString()
-    sellAmount = new BigNumber(10)
-      .pow(sellCurrency.decimals)
-      .dividedBy(sellCurrency.quantization)
-      .times(amount)
-      .times(1 + (sellCurrency.settleSpread || 0))
-      .integerValue(BigNumber.ROUND_FLOOR)
-      .abs()
-      .toString()
-  }
+  // console.log('sell :', sellSymbol, sellCurrency)
+  // console.log('buy  :', buySymbol, buyCurrency)
 
   let expiration // in hours
   expiration = Math.floor(Date.now() / (1000 * 3600))
@@ -84,8 +44,8 @@ module.exports = async (dvf, { symbol, amount, price, validFor, feeRate }) => {
   const starkOrder = {
     vaultIdSell: vaultIdSell,
     vaultIdBuy: vaultIdBuy,
-    amountSell: sellAmount,
-    amountBuy: buyAmount,
+    amountSell,
+    amountBuy,
     tokenSell: sellCurrency.starkTokenId,
     tokenBuy: buyCurrency.starkTokenId,
     nonce: dvf.util.generateRandomNonce(),


### PR DESCRIPTION
Order sell and buy amounts need to be calculated and rounded the same way as currently done on the backend to ensure amounts match and orders are verified correctly.

- Extracted buy and sell amount calculation out of create order method.
- Used the same calculation logic and code as the backend to compute buy and sell amounts.
