### PR TITLE
handle tokeninfo additio for ledger based on eth network

### DIFF
--- a/src/dvf.js
+++ b/src/dvf.js
@@ -51,7 +51,7 @@ module.exports = async (web3, userConfig = {}) => {
 
   // save web3 instance int it
   dvf.web3 = web3
-
+  dvf.chainId = await web3.eth.net.getId()
   // REVIEW: should we actually use web3.eth.defaultAccount ?
   // see: https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#raising_hand-account-list-reflects-user-preference
 

--- a/src/lib/stark/ledger/createSignedOrder.js
+++ b/src/lib/stark/ledger/createSignedOrder.js
@@ -30,7 +30,6 @@ module.exports = async (dvf, path, starkOrder) => {
   // to be used for both buy as sell tokens and
   // for transfer method as well as well
 
-  const chainId = await dvf.web3.eth.net.getId()
   let buyTokenAddress = buyCurrency.tokenAddress
 
   if (buyTokenAddress) {
@@ -39,7 +38,7 @@ module.exports = async (dvf, path, starkOrder) => {
     if (buyTokenInfo) {
       await eth.provideERC20TokenInformation(buyTokenInfo)
     } else {
-      if (chainId!==1) {
+      if (dvf.chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${buyTokenAddress}0000000000000000`,
@@ -65,7 +64,7 @@ module.exports = async (dvf, path, starkOrder) => {
     if (sellTokenInfo) {
       await eth.provideERC20TokenInformation(sellTokenInfo)
     } else {
-      if (chainId!==1) {
+      if (dvf.chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${sellTokenAddress}0000000000000000`,

--- a/src/lib/stark/ledger/createSignedOrder.js
+++ b/src/lib/stark/ledger/createSignedOrder.js
@@ -30,6 +30,7 @@ module.exports = async (dvf, path, starkOrder) => {
   // to be used for both buy as sell tokens and
   // for transfer method as well as well
 
+  const chainId = await dvf.web3.eth.net.getId()
   let buyTokenAddress = buyCurrency.tokenAddress
 
   if (buyTokenAddress) {
@@ -38,7 +39,7 @@ module.exports = async (dvf, path, starkOrder) => {
     if (buyTokenInfo) {
       await eth.provideERC20TokenInformation(buyTokenInfo)
     } else {
-      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+      if (chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${buyTokenAddress}0000000000000000`,
@@ -64,7 +65,7 @@ module.exports = async (dvf, path, starkOrder) => {
     if (sellTokenInfo) {
       await eth.provideERC20TokenInformation(sellTokenInfo)
     } else {
-      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+      if (chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${sellTokenAddress}0000000000000000`,

--- a/src/lib/stark/ledger/createSignedTransfer.js
+++ b/src/lib/stark/ledger/createSignedTransfer.js
@@ -28,13 +28,14 @@ module.exports = async (
   const eth = new Eth(transport)
   const { address } = await eth.getAddress(path)
   const starkPath = dvf.stark.ledger.getPath(address)
+  const chainId = await dvf.web3.eth.net.getId()
   if (transferTokenAddress) {
     const tokenInfo = byContractAddress(transferTokenAddress)
     transferTokenAddress = transferTokenAddress.substr(2)
     if (tokenInfo) {
       await eth.provideERC20TokenInformation(tokenInfo)
     } else {
-      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+      if (chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${transferTokenAddress}0000000000000000`,

--- a/src/lib/stark/ledger/createSignedTransfer.js
+++ b/src/lib/stark/ledger/createSignedTransfer.js
@@ -28,14 +28,13 @@ module.exports = async (
   const eth = new Eth(transport)
   const { address } = await eth.getAddress(path)
   const starkPath = dvf.stark.ledger.getPath(address)
-  const chainId = await dvf.web3.eth.net.getId()
   if (transferTokenAddress) {
     const tokenInfo = byContractAddress(transferTokenAddress)
     transferTokenAddress = transferTokenAddress.substr(2)
     if (tokenInfo) {
       await eth.provideERC20TokenInformation(tokenInfo)
     } else {
-      if (chainId!==1) {
+      if (dvf.chainId!==1) {
         let tokenInfo = {}
         tokenInfo['data'] = Buffer.from(
           `00${transferTokenAddress}0000000000000000`,


### PR DESCRIPTION
 - ERC20 Token Info needs a different logic for testnet tokens as compared to mainnet tokens. This is being handled in this fix by using chainId from web3.