### PR TITLE
bugfix/ledger invalid hex string bug

### DIFF
--- a/src/lib/stark/ledger/getPublicKey.js
+++ b/src/lib/stark/ledger/getPublicKey.js
@@ -13,5 +13,5 @@ module.exports = async (dvf, path) => {
     y: tempKey.substr(66)
   }
   await transport.close()
-  return dvf.stark.ledger.normaliseStarkKey(starkPublicKey)
+  return starkPublicKey
 }


### PR DESCRIPTION
Ensuring 64 characters public key is used for signing messages to avoid invalid hex string error.