### PR TITLE
Incorporate Settle Spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",
@@ -52,7 +52,7 @@
     "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60",
+    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",

--- a/src/api/getConfig.test.js
+++ b/src/api/getConfig.test.js
@@ -24,14 +24,15 @@ describe('dvf.getConfig', () => {
         ETH: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 0.1,
+          minOrderSize: 0.05,
+          settleSpread: 0,
           starkTokenId:
             '0xb333e3142fe16b78628f19bb15afddaef437e72d6d7f5c6c20c6801a27fba6'
         },
         USDT: {
           decimals: 6,
           quantization: 1,
-          minOrderSize: 25,
+          minOrderSize: 10,
           settleSpread: 0,
           starkTokenId:
             '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
@@ -40,7 +41,8 @@ describe('dvf.getConfig', () => {
         ZRX: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 40,
+          minOrderSize: 20,
+          settleSpread: 0,
           starkTokenId:
             '0x3901ee6a6c5ac0f6e284f4273b961b7e9f29d25367d31d90b75820473a202f7',
           tokenAddress: '0xcd077abedd831a3443ffbe24fb76661bbb17eb69'
@@ -48,7 +50,8 @@ describe('dvf.getConfig', () => {
         BTC: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 0.0001,
+          minOrderSize: 0.0004,
+          settleSpread: 0,
           starkTokenId:
             '0x21ef21d6b234cd669edd702dd3d1d017be888337010b950ae3679eb4194b4bc',
           tokenAddress: '0x40d8978500bf68324a51533cd6a21e3e59be324a'

--- a/src/api/getUserConfig.test.js
+++ b/src/api/getUserConfig.test.js
@@ -24,7 +24,8 @@ describe('dvf.getUserConfig', () => {
         ETH: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 0.1,
+          minOrderSize: 0.05,
+          settleSpread: 0,
           starkTokenId:
             '0xb333e3142fe16b78628f19bb15afddaef437e72d6d7f5c6c20c6801a27fba6',
           starkVaultId: 1000001
@@ -32,7 +33,7 @@ describe('dvf.getUserConfig', () => {
         USDT: {
           decimals: 6,
           quantization: 1,
-          minOrderSize: 25,
+          minOrderSize: 10,
           settleSpread: 0,
           starkTokenId:
             '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
@@ -42,7 +43,8 @@ describe('dvf.getUserConfig', () => {
         ZRX: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 40,
+          minOrderSize: 20,
+          settleSpread: 0,
           starkTokenId:
             '0x3901ee6a6c5ac0f6e284f4273b961b7e9f29d25367d31d90b75820473a202f7',
           tokenAddress: '0xcd077abedd831a3443ffbe24fb76661bbb17eb69',
@@ -51,7 +53,8 @@ describe('dvf.getUserConfig', () => {
         BTC: {
           decimals: 18,
           quantization: 10000000000,
-          minOrderSize: 0.0001,
+          minOrderSize: 0.0004,
+          settleSpread: 0,
           starkTokenId:
             '0x21ef21d6b234cd669edd702dd3d1d017be888337010b950ae3679eb4194b4bc',
           tokenAddress: '0x40d8978500bf68324a51533cd6a21e3e59be324a',

--- a/src/api/test/fixtures/getConf.js
+++ b/src/api/test/fixtures/getConf.js
@@ -13,14 +13,15 @@ module.exports = () => {
       ETH: {
         decimals: 18,
         quantization: 10000000000,
-        minOrderSize: 0.1,
+        minOrderSize: 0.05,
+        settleSpread: 0,
         starkTokenId:
           '0xb333e3142fe16b78628f19bb15afddaef437e72d6d7f5c6c20c6801a27fba6'
       },
       USDT: {
         decimals: 6,
         quantization: 1,
-        minOrderSize: 25,
+        minOrderSize: 10,
         settleSpread: 0,
         starkTokenId:
           '0x180bef8ae3462e919489763b84dc1dc700c45a249dec4d1136814a639f2dd7b',
@@ -29,7 +30,8 @@ module.exports = () => {
       ZRX: {
         decimals: 18,
         quantization: 10000000000,
-        minOrderSize: 40,
+        minOrderSize: 20,
+        settleSpread: 0,
         starkTokenId:
           '0x3901ee6a6c5ac0f6e284f4273b961b7e9f29d25367d31d90b75820473a202f7',
         tokenAddress: '0xcd077abedd831a3443ffbe24fb76661bbb17eb69'
@@ -37,7 +39,8 @@ module.exports = () => {
       BTC: {
         decimals: 18,
         quantization: 10000000000,
-        minOrderSize: 0.0001,
+        minOrderSize: 0.0004,
+        settleSpread: 0,
         starkTokenId:
           '0x21ef21d6b234cd669edd702dd3d1d017be888337010b950ae3679eb4194b4bc',
         tokenAddress: '0x40d8978500bf68324a51533cd6a21e3e59be324a'

--- a/src/lib/stark/createMarketOrder.js
+++ b/src/lib/stark/createMarketOrder.js
@@ -31,10 +31,15 @@ module.exports = async (dvf, { symbol, tokenToSell, amountToSell, worstCasePrice
   // symbol is changed if necessary to avoid making changes to computeBuySellData
   const flippedSymbol = `${sellSymbol}:${buySymbol}`
   const adjustedPrice = flippedSymbol === symbol ? worstCasePrice : toBN(1 / worstCasePrice)
+
+
+  const settleSpreadBuy = buyCurrency.settleSpread
+  const settleSpreadSell = sellCurrency.settleSpread
+
   const {
     amountSell,
     amountBuy
-  } = computeBuySellData(dvf, { symbol: flippedSymbol, amount: amountToSell.negated(), price: adjustedPrice, feeRate })
+  } = computeBuySellData(dvf, { symbol: flippedSymbol, amount: amountToSell.negated(), price: adjustedPrice, feeRate, settleSpreadBuy, settleSpreadSell })
 
   let expiration // in hours
   expiration = Math.floor(Date.now() / (1000 * 3600))

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -31,10 +31,13 @@ module.exports = async (dvf, { symbol, amount, price, validFor, feeRate }) => {
     }
   }
 
+  const settleSpreadBuy = buyCurrency.settleSpread
+  const settleSpreadSell = sellCurrency.settleSpread
+
   const {
     amountSell,
     amountBuy
-  } = computeBuySellData(dvf,{ symbol, amount, price, feeRate })
+  } = computeBuySellData(dvf,{ symbol, amount, price, feeRate, settleSpreadBuy, settleSpreadSell })
 
   // console.log('sell :', sellSymbol, sellCurrency)
   // console.log('buy  :', buySymbol, buyCurrency)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,9 +2856,9 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60":
+"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe":
   version "0.1.0"
-  resolved "https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60"
+  resolved "https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe"
   dependencies:
     "@hapi/joi" "^17.1.1"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Incorporate settle spread for stable tokens like USDT and BTC

- Latest settle spread is retrieved from user config
- This is sent to dvf-utils/computeBuySellData for amount calculations

**Note: This change is dependent on requires https://github.com/DeversiFi/launch-deversifi/pull/588** 