### PR TITLE
Bugfix/Market order computation for

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe",
+    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#b536084f856c7798fd8a289be70c6b9628e41d48",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",

--- a/src/api/submitMarketOrder.test.js
+++ b/src/api/submitMarketOrder.test.js
@@ -133,7 +133,7 @@ describe('dvf.submitOrder', () => {
     const expectedBody = {
       type: 'EXCHANGE MARKET',
       symbol,
-      amount: worstCaseAmountToRecieve.toFixed(8),
+      amount: worstCaseAmountToRecieve.toFixed(6),
       price: worstCasePriceAdjusted.toString(),
       meta: {
         starkPublicKey: {
@@ -155,8 +155,8 @@ describe('dvf.submitOrder', () => {
       expect(body.meta.starkSignature.recoveryParam).toBeLessThan(5)
       expect(typeof body.meta.starkOrder.expirationTimestamp).toBe('number')
       expect(typeof body.meta.starkOrder.nonce).toBe('number')
-      expect(body.meta.starkOrder.amountBuy).toBe('3326666667')
-      expect(body.meta.starkOrder.amountSell).toBe('100000000')
+      expect(body.meta.starkOrder.amountBuy).toBe('3326633400')
+      expect(body.meta.starkOrder.amountSell).toBe('99999000')
       return true
     })
 

--- a/src/lib/dvf/createMarketOrderMetaData.js
+++ b/src/lib/dvf/createMarketOrderMetaData.js
@@ -19,7 +19,7 @@ const starkSignedOrder = async (dvf, starkPrivateKey, starkMessage) => {
 module.exports = async (dvf, orderData) => {
   validateProps(dvf, ['amountToSell', 'symbol', 'tokenToSell', 'worstCasePrice'], orderData)
 
-  const { starkOrder, starkMessage } = await dvf.stark.createMarketOrder(orderData)
+  const { starkOrder, starkMessage } = await dvf.stark.createOrder(orderData)
 
   const { starkPublicKey, starkSignature } = await (orderData.ledgerPath
     ? dvf.stark.ledger.createSignedOrder(orderData.ledgerPath, starkOrder)

--- a/src/lib/dvf/createMarketOrderPayload.js
+++ b/src/lib/dvf/createMarketOrderPayload.js
@@ -1,5 +1,5 @@
 const FP = require('lodash/fp')
-const { Joi, toBN, prepareAmountBN } = require('dvf-utils')
+const { Joi, toBN, prepareAmount } = require('dvf-utils')
 
 /*
 repeating the schema here as this method can be called on its own
@@ -39,7 +39,7 @@ module.exports = async (dvf, orderData) => {
   const finalValue = {
     ...value,
     feeRate: value.feeRate || dvf.config.DVF.defaultFeeRate,
-    amount: prepareAmountBN(amountBN),
+    amount: prepareAmount(amountBN),
     price: value.worstCasePrice
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,9 +2856,9 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe":
+"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#b536084f856c7798fd8a289be70c6b9628e41d48":
   version "0.1.0"
-  resolved "https://github.com/DeversiFi/dvf-utils.git#ee433bf4014989a109a1869f51240116f2fa5dbe"
+  resolved "https://github.com/DeversiFi/dvf-utils.git#b536084f856c7798fd8a289be70c6b9628e41d48"
   dependencies:
     "@hapi/joi" "^17.1.1"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Using createOrder in place or CreateMarketOrder to ensure the same set of calculations take place on the front end and the back end. This ensures the order is validated correctly.

This requires: https://github.com/DeversiFi/dvf-utils/pull/2
and Backend to be updated as well.