### PR TITLE
Use Decimal Precision Based on Quantized Unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60",
+    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",

--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -2,15 +2,11 @@ const { post } = require('request-promise')
 const DVFError = require('../lib/dvf/DVFError')
 const validateAssertions = require('../lib/validators/validateAssertions')
 const prepareAmount = require('dvf-utils').prepareAmount
-const maxQuantizedDecimalPlaces = require('../lib/dvf/token/maxQuantizedDecimalPlaces')
 
 module.exports = async (dvf, token, amount, starkPrivateKey) => {
   validateAssertions(dvf, { amount, token, starkPrivateKey })
 
-  amount = prepareAmount(
-    amount,
-    Math.min(maxQuantizedDecimalPlaces(token), dvf.config.defaultDecimalPlaces)
-  )
+  amount = prepareAmount(amount, dvf.token.maxQuantizedDecimalPlaces(token))
 
   const currency = dvf.token.getTokenInfo(token)
   const quantisedAmount = dvf.token.toQuantizedAmount(token, amount)

--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -6,10 +6,10 @@ const maxQuantizedDecimalPlaces = require('../lib/dvf/token/maxQuantizedDecimalP
 
 module.exports = async (dvf, token, amount, starkPrivateKey) => {
   validateAssertions(dvf, { amount, token, starkPrivateKey })
-  
+
   amount = prepareAmount(
     amount,
-    Math.min(maxQuantizedDecimalPlaces(token), dvf.defaultDecimalPlaces)
+    Math.min(maxQuantizedDecimalPlaces(token), dvf.config.defaultDecimalPlaces)
   )
 
   const currency = dvf.token.getTokenInfo(token)

--- a/src/api/deposit.test.js
+++ b/src/api/deposit.test.js
@@ -14,7 +14,7 @@ describe('dvf.deposit', () => {
   it(`Deposits ERC20 token to user's vault`, async () => {
     mockGetConf()
     const starkPrivateKey = '100'
-    const amount = 1394
+    const amount = '1394'
     const token = 'USDT'
     const starkPublicKey = {
       x: '06d840e6d0ecfcbcfa83c0f704439e16c69383d93f51427feb9a4f2d21fbe075',
@@ -51,7 +51,7 @@ describe('dvf.deposit', () => {
     mockGetConf()
     const starkPrivateKey = '100'
     const token = 'ETH'
-    const amount = 1.117
+    const amount = '1.117'
     const apiResponse = {
       token,
       amount,
@@ -99,7 +99,7 @@ describe('dvf.deposit', () => {
   it('Gives error if token is missing', async () => {
     const starkPrivateKey =
       '3c1e9550e66958296d11b60f8e8e7a7ad990d07fa65d5f7652c4a6c87d4e3cc'
-    const amount = 57
+    const amount = '57'
     const token = ''
 
     try {
@@ -114,7 +114,7 @@ describe('dvf.deposit', () => {
   it('Gives error if token is not supported', async () => {
     const starkPrivateKey =
       '3c1e9550e66958296d11b60f8e8e7a7ad990d07fa65d5f7652c4a6c87d4e3cc'
-    const amount = 57
+    const amount = '57'
     const token = 'NOT'
 
     try {
@@ -128,7 +128,7 @@ describe('dvf.deposit', () => {
 
   it('Gives error if starkPrivateKey is not provided', async () => {
     const starkPrivateKey = ''
-    const amount = 57
+    const amount = '57'
     const token = 'ZRX'
 
     try {

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ module.exports = {
   api: 'https://api.stg.deversifi.com',
 
   // default decimal place precision for amount
-  defaultDecimals: 8,
+  defaultDecimalPlaces: 8,
   // default transaction arguments
   defaultGasLimit: 200000,
   defaultGasPrice: 14000000000,

--- a/src/config.js
+++ b/src/config.js
@@ -2,14 +2,19 @@ module.exports = {
   // api: 'https://api.deversifi.com',
   api: 'https://api.stg.deversifi.com',
 
+  // default decimal place precision for amount
+  defaultDecimals: 8,
   // default transaction arguments
   defaultGasLimit: 200000,
   defaultGasPrice: 14000000000,
+
+  // default stark related constants
   // default expiration time for transfers and orders in hours
   defaultStarkExpiry: 720,
   // default nonce age in seconds
   defaultNonceAge: 10800,
   // in case no provider is provided we will try connecting to the this default
+
   // address
   defaultProvider: 'http://localhost:8545',
 

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ module.exports = {
 
   // default transaction arguments
   defaultGasLimit: 200000,
-  defaultGasPrice: 14000000000,
+  defaultGasPrice: 30000000000,
 
   // default stark related constants
   // default expiration time for transfers and orders in hours

--- a/src/config.js
+++ b/src/config.js
@@ -2,8 +2,6 @@ module.exports = {
   // api: 'https://api.deversifi.com',
   api: 'https://api.stg.deversifi.com',
 
-  // default decimal place precision for amount
-  defaultDecimalPlaces: 8,
   // default transaction arguments
   defaultGasLimit: 200000,
   defaultGasPrice: 14000000000,

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -73,7 +73,8 @@ module.exports = () => {
     fromBaseUnitAmount: compose(require('./token/fromBaseUnitAmount')),
     fromQuantizedAmount: compose(require('./token/fromQuantizedAmount')),
     toBaseUnitAmount: compose(require('./token/toBaseUnitAmount')),
-    toQuantizedAmount: compose(require('./token/toQuantizedAmount'))
+    toQuantizedAmount: compose(require('./token/toQuantizedAmount')),
+    maxQuantizedDecimalPlaces: require('./token/maxQuantizedDecimalPlaces')
   }
 
   // dvf.eth functions

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -81,8 +81,7 @@ module.exports = () => {
   dvf.eth = {
     call: compose(require('../../api/eth/call')),
     send: compose(require('../../api/eth/send')),
-    getNetwork: compose(require('../../api/eth/getNetwork')),
-    getSafeGasPrice: compose(require('../../api/eth/getSafeGasPrice'))
+    getNetwork: compose(require('../../api/eth/getNetwork'))
   }
 
   // dvf utility functions

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -74,14 +74,15 @@ module.exports = () => {
     fromQuantizedAmount: compose(require('./token/fromQuantizedAmount')),
     toBaseUnitAmount: compose(require('./token/toBaseUnitAmount')),
     toQuantizedAmount: compose(require('./token/toQuantizedAmount')),
-    maxQuantizedDecimalPlaces: require('./token/maxQuantizedDecimalPlaces')
+    maxQuantizedDecimalPlaces: compose(require('./token/maxQuantizedDecimalPlaces'))
   }
 
   // dvf.eth functions
   dvf.eth = {
     call: compose(require('../../api/eth/call')),
     send: compose(require('../../api/eth/send')),
-    getNetwork: compose(require('../../api/eth/getNetwork'))
+    getNetwork: compose(require('../../api/eth/getNetwork')),
+    getSafeGasPrice: compose(require('../../api/eth/getSafeGasPrice'))
   }
 
   // dvf utility functions

--- a/src/lib/dvf/token/maxQuantizedDecimalPlaces.js
+++ b/src/lib/dvf/token/maxQuantizedDecimalPlaces.js
@@ -1,6 +1,7 @@
 const BN = require('bignumber.js')
 
-module.exports = (token) => {
+module.exports = (dvf, token) => {
+  console.log(dvf)
   const tokenInfo = dvf.token.getTokenInfo(token)
   const quantizedUnit = new BN(10).pow(tokenInfo.decimals).div(tokenInfo.quantization).toString()
   return (quantizedUnit.length-1)

--- a/src/lib/dvf/token/maxQuantizedDecimalPlaces.js
+++ b/src/lib/dvf/token/maxQuantizedDecimalPlaces.js
@@ -1,0 +1,7 @@
+const BN = require('bignumber.js')
+
+module.exports = (token) => {
+  const tokenInfo = dvf.token.getTokenInfo(token)
+  const quantizedUnit = new BN(10).pow(tokenInfo.decimals).div(tokenInfo.quantization).toString()
+  return (quantizedUnit.length-1)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,9 +2856,9 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60":
+"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0":
   version "0.1.0"
-  resolved "https://github.com/DeversiFi/dvf-utils.git#358904b5feca38c4cada021cadbaf81f240b3f60"
+  resolved "https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0"
   dependencies:
     "@hapi/joi" "^17.1.1"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Use the max decimal place precision possible based on a quantized unit and default decimal precision supported by BitFinex.
