### PR TITLE
Mapping between Bitfinex and Deversifi tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",
@@ -52,7 +52,7 @@
     "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0",
+    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "aigle": "^1.14.1",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git",
+    "dvf-utils": "https://github.com/DeversiFi/dvf-utils.git#2430ae042d7495f9619cdc0f3156c17bd94ab8b8",
     "env-cmd": "^10.0.1",
     "ethereumjs-util": "^5.2.0",
     "lodash": "^4.17.10",

--- a/src/dvf.js
+++ b/src/dvf.js
@@ -55,7 +55,7 @@ module.exports = async (web3, userConfig = {}) => {
   let chainId = 3
 
   try {
-    chainId = dvf.config.chainId || (await web3.eth.net.getId())
+    chainId = chainId || (await web3.eth.net.getId())
   }
   catch(e)  {
     console.log('error getting chainId')

--- a/src/lib/dvf/token/getTokenInfo.js
+++ b/src/lib/dvf/token/getTokenInfo.js
@@ -1,7 +1,5 @@
+const bfxTodvf = require('dvf-utils').BfxToDvfToken
+
 module.exports = (dvf, token) => {
-  if (token === 'USD') {
-    token = 'USDT'
-  }
-  
-  return dvf.config.tokenRegistry[token]
+  return dvf.config.tokenRegistry[bfxTodvf(token)]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,12 +2856,13 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0":
-  version "0.1.0"
-  resolved "https://github.com/DeversiFi/dvf-utils.git#bdcf7b9699831d3101a05a79014e0b2de11ce6b0"
+"dvf-utils@https://github.com/DeversiFi/dvf-utils.git#2430ae042d7495f9619cdc0f3156c17bd94ab8b8":
+  version "0.1.2"
+  resolved "https://github.com/DeversiFi/dvf-utils.git#2430ae042d7495f9619cdc0f3156c17bd94ab8b8"
   dependencies:
     "@hapi/joi" "^17.1.1"
     bignumber.js "^9.0.0"
+    ramda "^0.27.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -7259,6 +7260,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+ramda@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
+  integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- Using dvf utils method to convert between Deversifi and Bitfinex token names.
- This enables adding mapping between USDC and UDC plus others when required

Note: This PR is dependant on https://github.com/DeversiFi/dvf-utils/pull/4
yarn lock needs to be regenerated after dvf utils is merged