### PR TITLE
📥 Patch suggestion, adding trading API as envVars

### DIFF
--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -171,6 +171,7 @@ const go = async (configPath) => {
       JSON.stringify({
         INFURA_PROJECT_ID,
         ETH_PRIVATE_KEY: account.privateKey,
+        API: `https://api.stg.deversifi.com`,
         account
       }, null, 2)
     )

--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -6,6 +6,7 @@ const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')()
+const api = envVars.API
 
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -12,6 +12,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -19,7 +20,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -13,6 +13,8 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
+
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +22,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -13,6 +13,8 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
+
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +22,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -13,6 +13,8 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
+
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +22,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/14.getWithdrawals.js
+++ b/examples/14.getWithdrawals.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/15.getWithdrawal.js
+++ b/examples/15.getWithdrawal.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/16.withdrawOnChain.js
+++ b/examples/16.withdrawOnChain.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/17.fullWithdrawalRequest.js
+++ b/examples/17.fullWithdrawalRequest.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/18.getVaultId.js
+++ b/examples/18.getVaultId.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api:  api
   // Add more variables to override default values
 }
 

--- a/examples/19.ledgerDeposit.js
+++ b/examples/19.ledgerDeposit.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/20.ledgerSubmitOrder.js
+++ b/examples/20.ledgerSubmitOrder.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/21.ledgerWithdraw.js
+++ b/examples/21.ledgerWithdraw.js
@@ -13,6 +13,7 @@ const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // const starkPrivKey = dvf.stark.createPrivateKey()
 const starkPrivKey = ethPrivKey
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+const api = envVars.API
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)
 const web3 = new Web3(provider)
@@ -20,7 +21,7 @@ provider.engine.stop()
 
 const dvfConfig = {
   // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: api
   // Add more variables to override default values
 }
 

--- a/examples/helpers/loadFromEnvOrConfig.js
+++ b/examples/helpers/loadFromEnvOrConfig.js
@@ -36,6 +36,7 @@ module.exports = () => {
 
   return {
     INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID', config),
+    API: getConfigVar('API', config),
     ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY', config)
   }
 }


### PR DESCRIPTION
Please note that this is only a part of the patch and not meant to be merged.

The purpose of this example is to show the first step in a PR that:
Creates a seamless transition between stage API and the live API.

Extra steps:
1).
patch:   ./helpers/loadFromEnvOrConfig .
with:  API: getConfigVar('API', config) .

2).
patch:   every file in " ./examples "   that uses the API.
with:
 a) const api = envVars.API
 b) const dvfConfig = { api: api}

This is how i use to change the platform state with ease.
If it's something you would like to use just approve and i will create a
new PR with all the steps bundled.