### PR TITLE
examples: allow setting api url via env var / config.json

### DIFF
--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -158,6 +158,7 @@ const go = async (configPath) => {
       JSON.stringify({
         INFURA_PROJECT_ID,
         ETH_PRIVATE_KEY: account.privateKey,
+        API_URL: 'https://api.stg.deversifi.com',
         account
       }, null, 2)
     )

--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -20,6 +20,7 @@ const useTor = (!!process.env.USE_TOR)
 const createNewAccount = (!!process.env.CREATE_NEW_ACCOUNT)
 const useExistingAccount = (!!process.env.USE_EXISTING_ACCOUNT)
 const waitForBalance = (!!process.env.WAIT_FOR_BALANCE)
+const apiUrl = process.env.API_URL || 'https://api.stg.deversifi.com'
 
 if (!INFURA_PROJECT_ID) {
   console.error('Error: INFURA_PROJECT_ID not set')
@@ -158,7 +159,7 @@ const go = async (configPath) => {
       JSON.stringify({
         INFURA_PROJECT_ID,
         ETH_PRIVATE_KEY: account.privateKey,
-        API_URL: 'https://api.stg.deversifi.com',
+        API_URL: apiUrl,
         account
       }, null, 2)
     )

--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -7,6 +7,7 @@ const Web3 = require('web3')
 const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')()
 
+
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
@@ -18,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -6,7 +6,7 @@ const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')()
-const getPriceFromOrderBook = require('./helpers/getPriceFromOrderBook')
+
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -26,6 +26,8 @@ const dvfConfig = {
 
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
+
+  const getPriceFromOrderBook = require('./helpers/getPriceFromOrderBook')
 
   // Submit an order to sell 0.3 Eth for 200 USDT per 1 Eth
   const symbol = 'ETH:USDT'
@@ -57,3 +59,4 @@ const dvfConfig = {
   console.error(error)
   process.exit(1)
 })
+

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/14.getWithdrawals.js
+++ b/examples/14.getWithdrawals.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/15.getWithdrawal.js
+++ b/examples/15.getWithdrawal.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 
@@ -46,8 +45,12 @@ const dvfConfig = {
     withdrawalId = withdrawalResponse._id
   }
   else {
-    console.log('getWithdrawal response ->', withdrawals[0])
+    withdrawalId = withdrawals[0]._id
   }
+
+  const getWithdrawalResponse = await dvf.getWithdrawal(withdrawalId)
+
+  console.log('getWithdrawal response ->', getWithdrawalResponse)
 
 })()
 .catch(error => {

--- a/examples/16.withdrawOnChain.js
+++ b/examples/16.withdrawOnChain.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/17.fullWithdrawalRequest.js
+++ b/examples/17.fullWithdrawalRequest.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/18.getVaultId.js
+++ b/examples/18.getVaultId.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/19.ledgerDeposit.js
+++ b/examples/19.ledgerDeposit.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/20.ledgerSubmitOrder.js
+++ b/examples/20.ledgerSubmitOrder.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/21.ledgerWithdraw.js
+++ b/examples/21.ledgerWithdraw.js
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/helpers/buildExamples.js
+++ b/examples/helpers/buildExamples.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 
 Mustache = require('mustache')

--- a/examples/helpers/example.js.tmpl
+++ b/examples/helpers/example.js.tmpl
@@ -19,8 +19,7 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  // Using staging API.
-  api: 'https://api.stg.deversifi.com'
+  api: envVars.API_URL
   // Add more variables to override default values
 }
 

--- a/examples/helpers/loadFromEnvOrConfig.js
+++ b/examples/helpers/loadFromEnvOrConfig.js
@@ -1,8 +1,8 @@
 fs = require('fs')
 
 
-const getConfigVar = (varName, config) => {
-  const value = process.env[ varName ] || config[ varName ]
+const getConfigVar = (varName, config, defaultValue) => {
+  const value = process.env[ varName ] || config[ varName ] || defaultValue
 
   if (value) {
     return value
@@ -36,6 +36,9 @@ module.exports = () => {
 
   return {
     INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID', config),
-    ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY', config)
+    ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY', config),
+    API_URL: getConfigVar(
+      'API_URL', config, 'https://api.stg.deversifi.com'
+    )
   }
 }

--- a/examples/src/submitOrder.js
+++ b/examples/src/submitOrder.js
@@ -1,9 +1,15 @@
+const getPriceFromOrderBook = require('./helpers/getPriceFromOrderBook')
+
 // Submit an order to sell 0.3 Eth for 200 USDT per 1 Eth
 const symbol = 'ETH:USDT'
 const amount = -0.3
-const price = 200
 const validFor = '0'
 const feeRate = ''
+
+// Gets the price from the order book api and cuts 5% to make sure the order will be settled
+const tickersData = await dvf.getTickers('ETH:USDT');
+const orderBookPrice = getPriceFromOrderBook(tickersData);
+const price = orderBookPrice - orderBookPrice * 0.05;
 
 const submitOrderResponse = await dvf.submitOrder({
   symbol,


### PR DESCRIPTION
this supersedes #109 as Meers last comment on that PR has not been addressed

also:
- update examples/src/submitOrder (as the example was edited directly not
  following what's described in https://github.com/DeversiFi/dvf-client-js/pull/109#issuecomment-674391263)
- make examples/helpers/buildExamples.js executable so that it can be run
  directly