### PR TITLE
bunch of improvements to examples

### DIFF
--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -186,7 +186,7 @@ const go = async (configPath) => {
 
   if (waitForBalance) {
     await P.retry(
-      { times: 120, interval: 1000 },
+      { times: 360, interval: 1000 },
       hasSufficientBalanceOrThrow
     )
   }

--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -17,10 +17,10 @@ const request = require('./helpers/request')
 const saveAsJson = require('./helpers/saveAsJson')
 
 const INFURA_PROJECT_ID = process.argv[2]
-const useTor = (!!process.env.USE_TOR)
-const createNewAccount = (!!process.env.CREATE_NEW_ACCOUNT)
-const useExistingAccount = (!!process.env.USE_EXISTING_ACCOUNT)
-const waitForBalance = (!!process.env.WAIT_FOR_BALANCE)
+const useTor = process.env.USE_TOR === 'true'
+const createNewAccount = process.env.CREATE_NEW_ACCOUNT === 'true'
+const useExistingAccount = process.env.USE_EXISTING_ACCOUNT === 'true'
+const waitForBalance = process.env.WAIT_FOR_BALANCE === 'true'
 const apiUrl = process.env.API_URL || 'https://api.stg.deversifi.com'
 
 if (!INFURA_PROJECT_ID) {
@@ -28,7 +28,7 @@ if (!INFURA_PROJECT_ID) {
   console.error('\nusage: ./0.setup.js INFURA_PROJECT_ID')
   console.error('\n  you can obtain an INFURA_PROJECT_ID by following instructions here: https://ethereumico.io/knowledge-base/infura-api-key-guide ')
   console.error('    NOTE: the `API KEY` mentioned in the instructions has been renamed to `PROJECT ID`.')
-  console.error('\n  if you get an error when requesting Eth from a faucet, set USE_TOR=1 env var to make requests via a TOR (using https://www.npmjs.com/package/tor-request)')
+  console.error('\n  if you get an error when requesting Eth from a faucet, set USE_TOR=true env var to make requests via a TOR (using https://www.npmjs.com/package/tor-request)')
   console.error('    NOTE: tor executable needs to be on your path for this to work (it will be started/stopped automatically)')
   console.error('    tor can be installed via brew on MacOS or using your distros package manager if you are using linux')
   process.exit(1)

--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -14,6 +14,7 @@ const P = require('aigle')
 
 const spawnProcess = require('./helpers/spawnProcess')
 const request = require('./helpers/request')
+const saveAsJson = require('./helpers/saveAsJson')
 
 const INFURA_PROJECT_ID = process.argv[2]
 const useTor = (!!process.env.USE_TOR)
@@ -154,15 +155,12 @@ const go = async (configPath) => {
 
     console.log('Created new Ethereum account:', account.address)
 
-    fs.writeFileSync(
-      configFilePath,
-      JSON.stringify({
-        INFURA_PROJECT_ID,
-        ETH_PRIVATE_KEY: account.privateKey,
-        API_URL: apiUrl,
-        account
-      }, null, 2)
-    )
+    saveAsJson(configFilePath, {
+      INFURA_PROJECT_ID,
+      ETH_PRIVATE_KEY: account.privateKey,
+      API_URL: apiUrl,
+      account
+    })
 
     console.log(`Created ./${configFileName}`)
   }

--- a/examples/00.setup.js
+++ b/examples/00.setup.js
@@ -21,7 +21,8 @@ const useTor = process.env.USE_TOR === 'true'
 const createNewAccount = process.env.CREATE_NEW_ACCOUNT === 'true'
 const useExistingAccount = process.env.USE_EXISTING_ACCOUNT === 'true'
 const waitForBalance = process.env.WAIT_FOR_BALANCE === 'true'
-const apiUrl = process.env.API_URL || 'https://api.stg.deversifi.com'
+const API_URL = process.env.API_URL || 'https://api.stg.deversifi.com'
+const DATA_API_URL = process.env.DATA_API_URL || API_URL
 
 if (!INFURA_PROJECT_ID) {
   console.error('Error: INFURA_PROJECT_ID not set')
@@ -158,7 +159,8 @@ const go = async (configPath) => {
     saveAsJson(configFilePath, {
       INFURA_PROJECT_ID,
       ETH_PRIVATE_KEY: account.privateKey,
-      API_URL: apiUrl,
+      API_URL,
+      DATA_API_URL,
       account
     })
 

--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -31,7 +32,7 @@ const dvfConfig = {
 
   const registerResponse = await dvf.register(keyPair.starkPublicKey)
 
-  console.log('register response ->', registerResponse)
+  logExampleResult(registerResponse)
 
 })()
 .catch(error => {

--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const depositResponse = await dvf.deposit('ETH', 0.70, starkPrivKey)
 
-  console.log('deposit response ->', depositResponse)
+  logExampleResult(depositResponse)
 
 })()
 .catch(error => {

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -28,7 +28,13 @@ const dvfConfig = {
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
 
+  const waitForDepositCreditedOnChain = require('./helpers/waitForDepositCreditedOnChain')
+
   const depositResponse = await dvf.deposit('ETH', 0.70, starkPrivKey)
+
+  if (process.env.WAIT_FOR_DEPOSIT_READY === 'true') {
+    await waitForDepositCreditedOnChain(dvf, depositResponse)
+  }
 
   logExampleResult(depositResponse)
 

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getDepositsResponse = await dvf.getDeposits()
 
-  console.log('getDeposits response ->', getDepositsResponse)
+  logExampleResult(getDepositsResponse)
 
 })()
 .catch(error => {

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getBalanceResponse = await dvf.getBalance()
 
-  console.log('getBalance response ->', getBalanceResponse)
+  logExampleResult(getBalanceResponse)
 
 })()
 .catch(error => {

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -30,9 +30,9 @@ const dvfConfig = {
 
   const getPriceFromOrderBook = require('./helpers/getPriceFromOrderBook')
 
-  // Submit an order to sell 0.3 Eth for 200 USDT per 1 Eth
+  // Submit an order to sell 0.1 Eth for USDT
   const symbol = 'ETH:USDT'
-  const amount = -0.3
+  const amount = -0.1
   const validFor = '0'
   const feeRate = ''
 

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -52,7 +53,7 @@ const dvfConfig = {
     partnerId: 'P1'    // Optional
   })
 
-  console.log('submitOrder response ->', submitOrderResponse)
+  logExampleResult(submitOrderResponse)
 
 })()
 .catch(error => {

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getOrdersResponse = await dvf.getOrders()
 
-  console.log('getOrders response ->', getOrdersResponse)
+  logExampleResult(getOrdersResponse)
 
 })()
 .catch(error => {

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -28,6 +28,11 @@ const dvfConfig = {
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
 
+  const getOrCreateActiveOrder = require('./helpers/getOrCreateActiveOrder')
+
+  // Ensure that there is at least one order to get.
+  await getOrCreateActiveOrder(dvf, starkPrivKey)
+
   const getOrdersResponse = await dvf.getOrders()
 
   logExampleResult(getOrdersResponse)

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -28,37 +28,16 @@ const dvfConfig = {
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
 
+  const getOrCreateActiveOrder = require('./helpers/getOrCreateActiveOrder')
 
-  const symbol = 'BTC:USDT'
+  const symbol = 'ETH:USDT'
 
-  let orders = await dvf.getOrders(symbol)
+  // Ensure that there is at least one order to get.
+  await getOrCreateActiveOrder(dvf, starkPrivKey, { symbol })
 
-  if (orders.length == 0) {
+  const getOrdersResponse = await dvf.getOrders(symbol)
 
-    console.log(`no orders for ${symbol}, submitting one`)
-
-    // Submit an order to buy 0.02 BTC at a rate of 7000 USDT for 1 BTC
-    const amount = 0.02
-    const price = 7000
-    const validFor = '0'
-    const feeRate = ''
-
-    const submitOrderResponse = await dvf.submitOrder({
-      symbol,
-      amount,
-      price,
-      starkPrivateKey: starkPrivKey,
-      validFor,           // Optional
-      feeRate,            // Optional
-      gid: '1',           // Optional
-      cid: '1',           // Optional
-      partnerId: 'P1'    // Optional
-    })
-  }
-
-  orders = await dvf.getOrders(symbol)
-
-  logExampleResult(orders)
+  logExampleResult(getOrdersResponse)
 
 })()
 .catch(error => {

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -57,7 +58,7 @@ const dvfConfig = {
 
   orders = await dvf.getOrders(symbol)
 
-  console.log("getOrders(symbol) response ->", orders)
+  logExampleResult(orders)
 
 })()
 .catch(error => {

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -34,7 +35,7 @@ const dvfConfig = {
 
   if (orders.length == 0) {
     console.log('submitting new order')
-    
+
     // Submit an order to buy 0.5 Eth at a rate of 200 USDT for 1 Eth
     const symbol = 'ETH:USDT'
     const amount = 0.5
@@ -66,7 +67,7 @@ const dvfConfig = {
 
   const response = await dvf.cancelOrder(orderId)
 
-  console.log("cancelOrder response ->", response)
+  logExampleResult("cancelOrder response ->", response)
 
 })()
 .catch(error => {

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -28,18 +28,19 @@ const dvfConfig = {
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
 
+  const P = require('aigle')
   let orderId
-  const orders = await dvf.getOrders('ETH:USDT')
+  const orders = await dvf.getOrders()
 
   console.log('orders', orders)
 
   if (orders.length == 0) {
     console.log('submitting new order')
 
-    // Submit an order to buy 0.5 Eth at a rate of 200 USDT for 1 Eth
+    // Submit an order to sell 0.1 ETH at a the price of 5000 USDT per ETH
     const symbol = 'ETH:USDT'
-    const amount = 0.5
-    const price = 200
+    const amount = -0.1
+    const price = 5000
     const validFor = '0'
     const feeRate = ''
 
@@ -58,6 +59,12 @@ const dvfConfig = {
     console.log('submitOrder response ->', submitOrderResponse)
 
     orderId = submitOrderResponse._id
+
+    while (true) {
+      console.log('checking if order appears on the book...')
+      if ((await dvf.getOrders()).find(o => o._id === orderId)) break
+      await P.delay(1000)
+    }
   }
   else {
     orderId = orders[0]._id
@@ -67,7 +74,7 @@ const dvfConfig = {
 
   const response = await dvf.cancelOrder(orderId)
 
-  logExampleResult("cancelOrder response ->", response)
+  logExampleResult(response)
 
 })()
 .catch(error => {

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getConfigResponse = await dvf.getConfig()
 
-  console.log('getConfig response ->', getConfigResponse)
+  logExampleResult(getConfigResponse)
 
 })()
 .catch(error => {

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -65,7 +66,7 @@ const dvfConfig = {
 
   const response = await dvf.getOrder(orderId)
 
-  console.log("getOrder response ->", response)
+  logExampleResult("getOrder response ->", response)
 
 })()
 .catch(error => {

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -28,45 +28,13 @@ const dvfConfig = {
 ;(async () => {
   const dvf = await DVF(web3, dvfConfig)
 
-  let orderId
-  const orders = await dvf.getOrders('ETH:USDT')
+  const getOrCreateActiveOrder = require('./helpers/getOrCreateActiveOrder')
 
-  console.log('orders', orders)
+  const order = await getOrCreateActiveOrder(dvf, starkPrivKey)
 
-  if (orders.length == 0) {
-    console.log('submitting new order')
+  const response = await dvf.getOrder(order._id)
 
-    // Submit an order to buy 0.3 ETH at a rate of 180 USDT per 1 ETH
-    const symbol = 'ETH:USDT'
-    const amount = 0.3
-    const price = 180
-    const validFor = '0'
-    const feeRate = ''
-
-    const submitOrderResponse = await dvf.submitOrder({
-      symbol,
-      amount,
-      price,
-      starkPrivateKey: starkPrivKey,
-      validFor,           // Optional
-      feeRate,            // Optional
-      gid: '1',           // Optional
-      cid: '1',           // Optional
-      partnerId: 'P1'    // Optional
-    })
-
-    console.log('submitOrder response ->', submitOrderResponse)
-    orderId = submitOrderResponse._id
-  }
-  else {
-    orderId = orders[0]._id
-  }
-
-  console.log('fetching orderId', orderId)
-
-  const response = await dvf.getOrder(orderId)
-
-  logExampleResult("getOrder response ->", response)
+  logExampleResult(response)
 
 })()
 .catch(error => {

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getOrdersHistResponse = await dvf.getOrdersHist()
 
-  console.log('getOrdersHist response ->', getOrdersHistResponse)
+  logExampleResult(getOrdersHistResponse)
 
 })()
 .catch(error => {

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getUserConfigResponse = await dvf.getUserConfig()
 
-  console.log('getUserConfig response ->', getUserConfigResponse)
+  logExampleResult(getUserConfigResponse)
 
 })()
 .catch(error => {

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -36,7 +37,7 @@ const dvfConfig = {
     starkPrivKey
   )
 
-  console.log('withdraw response ->', withdrawalResponse)
+  logExampleResult(withdrawalResponse)
 
 })()
 .catch(error => {

--- a/examples/14.getWithdrawals.js
+++ b/examples/14.getWithdrawals.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/14.getWithdrawals.js
+++ b/examples/14.getWithdrawals.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -29,7 +30,7 @@ const dvfConfig = {
 
   const getWithdrawalsResponse = await dvf.getWithdrawals()
 
-  console.log('getWithdrawals response ->', getWithdrawalsResponse)
+  logExampleResult(getWithdrawalsResponse)
 
 })()
 .catch(error => {

--- a/examples/14.getWithdrawals.js
+++ b/examples/14.getWithdrawals.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/15.getWithdrawal.js
+++ b/examples/15.getWithdrawal.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/15.getWithdrawal.js
+++ b/examples/15.getWithdrawal.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/15.getWithdrawal.js
+++ b/examples/15.getWithdrawal.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -51,7 +52,7 @@ const dvfConfig = {
 
   const getWithdrawalResponse = await dvf.getWithdrawal(withdrawalId)
 
-  console.log('getWithdrawal response ->', getWithdrawalResponse)
+  logExampleResult(getWithdrawalResponse)
 
 })()
 .catch(error => {

--- a/examples/16.withdrawOnChain.js
+++ b/examples/16.withdrawOnChain.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -31,7 +32,7 @@ const dvfConfig = {
 
   const withdrawalResponse = await dvf.withdrawOnchain(token)
 
-  console.log('withdraw onchain response ->', withdrawalResponse)
+  logExampleResult(withdrawalResponse)
 
 })()
 .catch(error => {

--- a/examples/16.withdrawOnChain.js
+++ b/examples/16.withdrawOnChain.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/16.withdrawOnChain.js
+++ b/examples/16.withdrawOnChain.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/17.fullWithdrawalRequest.js
+++ b/examples/17.fullWithdrawalRequest.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/17.fullWithdrawalRequest.js
+++ b/examples/17.fullWithdrawalRequest.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/17.fullWithdrawalRequest.js
+++ b/examples/17.fullWithdrawalRequest.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -31,7 +32,7 @@ const dvfConfig = {
 
   const withdrawalResponse = await dvf.fullWithdrawalRequest(token)
 
-  console.log('Full withdrawal request response ->', withdrawalResponse)
+  logExampleResult(withdrawalResponse)
 
 })()
 .catch(error => {

--- a/examples/18.getVaultId.js
+++ b/examples/18.getVaultId.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/18.getVaultId.js
+++ b/examples/18.getVaultId.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/18.getVaultId.js
+++ b/examples/18.getVaultId.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -31,7 +32,7 @@ const dvfConfig = {
 
   const getVaultIdResponse = await dvf.getVaultId(token)
 
-  console.log('getVaultId response ->', getVaultIdResponse)
+  logExampleResult(getVaultIdResponse)
 
 })()
 .catch(error => {

--- a/examples/19.ledgerDeposit.js
+++ b/examples/19.ledgerDeposit.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/19.ledgerDeposit.js
+++ b/examples/19.ledgerDeposit.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -43,7 +44,7 @@ const dvfConfig = {
     starkDepositData
   )
 
-  console.log('deposit response ->', depositResponse)
+  logExampleResult(depositResponse)
 
 })()
 .catch(error => {

--- a/examples/19.ledgerDeposit.js
+++ b/examples/19.ledgerDeposit.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/20.ledgerSubmitOrder.js
+++ b/examples/20.ledgerSubmitOrder.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/20.ledgerSubmitOrder.js
+++ b/examples/20.ledgerSubmitOrder.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -47,7 +48,7 @@ const dvfConfig = {
     partnerId: 'P1'    // Optional
   })
 
-  console.log('submitOrder response ->', submitOrderResponse)
+  logExampleResult(submitOrderResponse)
 
 })()
 .catch(error => {

--- a/examples/20.ledgerSubmitOrder.js
+++ b/examples/20.ledgerSubmitOrder.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/21.ledgerWithdraw.js
+++ b/examples/21.ledgerWithdraw.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/21.ledgerWithdraw.js
+++ b/examples/21.ledgerWithdraw.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -43,7 +44,7 @@ const dvfConfig = {
     starkWithdrawalData
   )
 
-  console.log('withdraw response ->', withdrawResponse)
+  logExampleResult(withdrawResponse)
 
 })()
 .catch(error => {

--- a/examples/21.ledgerWithdraw.js
+++ b/examples/21.ledgerWithdraw.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/22.cancelWithdrawal.js
+++ b/examples/22.cancelWithdrawal.js
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/22.cancelWithdrawal.js
+++ b/examples/22.cancelWithdrawal.js
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/22.cancelWithdrawal.js
+++ b/examples/22.cancelWithdrawal.js
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
@@ -51,7 +52,7 @@ const dvfConfig = {
 
   const canceledWithdrawal = await dvf.cancelWithdrawal(withdrawalId)
 
-  console.log('cancelWithdrawal response ->', canceledWithdrawal)
+  logExampleResult(canceledWithdrawal)
 
 })()
 .catch(error => {

--- a/examples/helpers/example.js.tmpl
+++ b/examples/helpers/example.js.tmpl
@@ -5,8 +5,9 @@ const sw = require('starkware_crypto')
 const Web3 = require('web3')
 
 const DVF = require('../src/dvf')
-const envVars = require('./helpers/loadFromEnvOrConfig')()
-
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/helpers/example.js.tmpl
+++ b/examples/helpers/example.js.tmpl
@@ -8,6 +8,7 @@ const DVF = require('../src/dvf')
 const envVars = require('./helpers/loadFromEnvOrConfig')(
   process.env.CONFIG_FILE_NAME
 )
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
 
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`

--- a/examples/helpers/example.js.tmpl
+++ b/examples/helpers/example.js.tmpl
@@ -21,7 +21,8 @@ const web3 = new Web3(provider)
 provider.engine.stop()
 
 const dvfConfig = {
-  api: envVars.API_URL
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
   // Add more variables to override default values
 }
 

--- a/examples/helpers/loadFromEnvOrConfig.js
+++ b/examples/helpers/loadFromEnvOrConfig.js
@@ -1,7 +1,7 @@
 fs = require('fs')
+path = require('path')
 
-
-const getConfigVar = (varName, config, defaultValue) => {
+const getConfigVar_ = (config, configFileName) => (varName, defaultValue) => {
   const value = process.env[ varName ] || config[ varName ] || defaultValue
 
   if (value) {
@@ -9,36 +9,37 @@ const getConfigVar = (varName, config, defaultValue) => {
   }
   else {
     throw new Error(
-      `${varName} is required. Set it in ./config.json or via an env var.`
+      `${varName} is required. Set it in ${configFileName} or via an env var.`
     )
   }
-
 }
 
-
-module.exports = () => {
+module.exports = (configFileName = 'config.json') => {
+  const configFilePath = path.normalize(
+    path.join(__dirname, '..', configFileName)
+  )
 
   let config = {}
 
   try {
     config = JSON.parse(
-      fs.readFileSync(`${__dirname}/../config.json`).toString()
+      fs.readFileSync(configFilePath).toString()
     )
   }
   catch (error) {
     if (error.code == 'ENOENT') {
-      console.log('warning: ./config.json not found')
+      console.log(`warning: ${configFilePath} not found`)
     }
     else {
       throw error
     }
   }
 
+  const getConfigVar = getConfigVar_(config, configFilePath)
+
   return {
-    INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID', config),
-    ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY', config),
-    API_URL: getConfigVar(
-      'API_URL', config, 'https://api.stg.deversifi.com'
-    )
+    INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID'),
+    ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY'),
+    API_URL: getConfigVar('API_URL', 'https://api.stg.deversifi.com')
   }
 }

--- a/examples/helpers/loadFromEnvOrConfig.js
+++ b/examples/helpers/loadFromEnvOrConfig.js
@@ -37,9 +37,12 @@ module.exports = (configFileName = 'config.json') => {
 
   const getConfigVar = getConfigVar_(config, configFilePath)
 
+  const apiUrl = getConfigVar('API_URL', 'https://api.stg.deversifi.com')
+
   return {
     INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID'),
     ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY'),
-    API_URL: getConfigVar('API_URL', 'https://api.stg.deversifi.com')
+    API_URL: apiUrl,
+    DATA_API_URL: getConfigVar('DATA_API_URL', apiUrl)
   }
 }

--- a/examples/helpers/logExampleResult.js
+++ b/examples/helpers/logExampleResult.js
@@ -1,0 +1,16 @@
+const path = require('path')
+const saveAsJson = require('./saveAsJson')
+
+module.exports = exampleFilename => content => {
+  const resultsDir = process.env.SAVE_EXAMPLE_RESULTS_TO_DIR
+
+  const { name, base } = path.parse(exampleFilename)
+
+  if (resultsDir) {
+    fs.mkdirSync(resultsDir, { recursive: true })
+
+    saveAsJson(path.join(resultsDir, `${name}.json`), content)
+  }
+
+  console.log(`${base} response ->`, content)
+}

--- a/examples/helpers/logMyIP.js
+++ b/examples/helpers/logMyIP.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const P = require('aigle')
+
+const request = require('./request')
+
+module.exports = useTor => P.retry(
+  { times: 10, interval: 100 },
+  () => request(useTor, 'http://ifconfig.me')
+)
+.then(r => console.log('current IP is:', r.body))
+.catch(error => console.error(
+  'error while obtaining current IP:', error.message || error.error
+))

--- a/examples/helpers/methodWithNoArgsTemplate.js.tmpl
+++ b/examples/helpers/methodWithNoArgsTemplate.js.tmpl
@@ -1,3 +1,3 @@
 const {{{METHOD_NAME}}}Response = await dvf.{{{METHOD_NAME}}}()
 
-console.log('{{{METHOD_NAME}}} response ->', {{{METHOD_NAME}}}Response)
+logExampleResult({{{METHOD_NAME}}}Response)

--- a/examples/helpers/saveAsJson.js
+++ b/examples/helpers/saveAsJson.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+
+module.exports = (filePath, content, stringifyOpts = [null, 2 ]) => {
+  return fs.writeFileSync(
+    filePath,
+    JSON.stringify.apply(JSON, [content].concat(stringifyOpts))
+  )
+}

--- a/examples/helpers/testExamples.js
+++ b/examples/helpers/testExamples.js
@@ -8,8 +8,8 @@ const spawnProcess = require('./spawnProcess')
 
 const configSchema = Joi.object().keys({
   INFURA_PROJECT_ID: Joi.string().required(),
-  SETUP_TIMEOUT: Joi.number().integer().default(5 * 60000),
-  TEST_TIMEOUT: Joi.number().integer().default(5 * 60000),
+  SETUP_TIMEOUT: Joi.number().integer().default(10 * 60000),
+  TEST_TIMEOUT: Joi.number().integer().default(10 * 60000),
   CONFIG_FILE_NAME: Joi.string().default(`config-test-${new Date().toISOString()}.js`),
   WAIT_FOR_DEPOSIT_READY: Joi.boolean().default(true),
   WAIT_FOR_BALANCE: Joi.boolean().default(true),

--- a/examples/helpers/testExamples.js
+++ b/examples/helpers/testExamples.js
@@ -25,7 +25,7 @@ const testExample = async (fileName) => {
   const timeout = 60000
 
   return Promise.all([
-    waitForLog({match:/.*response ->*/, timeout}),
+    waitForLog({ match: new RegExp(`${fileName} response ->`), timeout }),
     waitForCleanExit(timeout)
   ])
 }

--- a/examples/helpers/waitForDepositCreditedOnChain.js
+++ b/examples/helpers/waitForDepositCreditedOnChain.js
@@ -1,0 +1,15 @@
+const P = require('aigle')
+
+module.exports = async (dvf, deposit) => {
+  console.log('waiting for deposit to be credited on chain...')
+
+  while (true) {
+    // TODO: add getDeposit to pub-api and client and use it here.
+    const deposits = await dvf.getDeposits(deposit.token)
+    if (deposits.find(d => d._id === deposit._id && d.status === 'ready')) {
+      break
+    }
+    console.log('still waiting...')
+    await P.delay(2000)
+  }
+}

--- a/examples/src/cancelOrder.js
+++ b/examples/src/cancelOrder.js
@@ -1,15 +1,16 @@
+const P = require('aigle')
 let orderId
-const orders = await dvf.getOrders('ETH:USDT')
+const orders = await dvf.getOrders()
 
 console.log('orders', orders)
 
 if (orders.length == 0) {
   console.log('submitting new order')
 
-  // Submit an order to buy 0.5 Eth at a rate of 200 USDT for 1 Eth
+  // Submit an order to sell 0.1 ETH at a the price of 5000 USDT per ETH
   const symbol = 'ETH:USDT'
-  const amount = 0.5
-  const price = 200
+  const amount = -0.1
+  const price = 5000
   const validFor = '0'
   const feeRate = ''
 
@@ -28,6 +29,12 @@ if (orders.length == 0) {
   console.log('submitOrder response ->', submitOrderResponse)
 
   orderId = submitOrderResponse._id
+
+  while (true) {
+    console.log('checking if order appears on the book...')
+    if ((await dvf.getOrders()).find(o => o._id === orderId)) break
+    await P.delay(1000)
+  }
 }
 else {
   orderId = orders[0]._id
@@ -37,4 +44,4 @@ console.log('cancelling orderId', orderId)
 
 const response = await dvf.cancelOrder(orderId)
 
-logExampleResult("cancelOrder response ->", response)
+logExampleResult(response)

--- a/examples/src/cancelOrder.js
+++ b/examples/src/cancelOrder.js
@@ -5,7 +5,7 @@ console.log('orders', orders)
 
 if (orders.length == 0) {
   console.log('submitting new order')
-  
+
   // Submit an order to buy 0.5 Eth at a rate of 200 USDT for 1 Eth
   const symbol = 'ETH:USDT'
   const amount = 0.5
@@ -37,4 +37,4 @@ console.log('cancelling orderId', orderId)
 
 const response = await dvf.cancelOrder(orderId)
 
-console.log("cancelOrder response ->", response)
+logExampleResult("cancelOrder response ->", response)

--- a/examples/src/cancelWithdrawal.js
+++ b/examples/src/cancelWithdrawal.js
@@ -1,0 +1,25 @@
+let withdrawalId
+const withdrawals = await dvf.getWithdrawals()
+
+if (withdrawals.length == 0) {
+  console.log('creating a new withdrawal')
+
+  const token = 'ETH'
+  const amount = 0.1
+
+  const withdrawalResponse = await dvf.withdraw(
+    token,
+    amount,
+    starkPrivKey
+  )
+
+  console.log('withdrawalResponse', withdrawalResponse)
+  withdrawalId = withdrawalResponse._id
+}
+else {
+  withdrawalId = withdrawals[0]._id
+}
+
+const canceledWithdrawal = await dvf.cancelWithdrawal(withdrawalId)
+
+logExampleResult(canceledWithdrawal)

--- a/examples/src/deposit.js
+++ b/examples/src/deposit.js
@@ -1,3 +1,3 @@
 const depositResponse = await dvf.deposit('ETH', 0.70, starkPrivKey)
 
-console.log('deposit response ->', depositResponse)
+logExampleResult(depositResponse)

--- a/examples/src/deposit.js
+++ b/examples/src/deposit.js
@@ -1,3 +1,9 @@
+const waitForDepositCreditedOnChain = require('./helpers/waitForDepositCreditedOnChain')
+
 const depositResponse = await dvf.deposit('ETH', 0.70, starkPrivKey)
+
+if (process.env.WAIT_FOR_DEPOSIT_READY === 'true') {
+  await waitForDepositCreditedOnChain(dvf, depositResponse)
+}
 
 logExampleResult(depositResponse)

--- a/examples/src/fullWithdrawalRequest.js
+++ b/examples/src/fullWithdrawalRequest.js
@@ -2,4 +2,4 @@ const token = 'ETH'
 
 const withdrawalResponse = await dvf.fullWithdrawalRequest(token)
 
-console.log('Full withdrawal request response ->', withdrawalResponse)
+logExampleResult(withdrawalResponse)

--- a/examples/src/getOrder.js
+++ b/examples/src/getOrder.js
@@ -36,4 +36,4 @@ console.log('fetching orderId', orderId)
 
 const response = await dvf.getOrder(orderId)
 
-console.log("getOrder response ->", response)
+logExampleResult(response)

--- a/examples/src/getOrder.js
+++ b/examples/src/getOrder.js
@@ -1,39 +1,7 @@
-let orderId
-const orders = await dvf.getOrders('ETH:USDT')
+const getOrCreateActiveOrder = require('./helpers/getOrCreateActiveOrder')
 
-console.log('orders', orders)
+const order = await getOrCreateActiveOrder(dvf, starkPrivKey)
 
-if (orders.length == 0) {
-  console.log('submitting new order')
-
-  // Submit an order to buy 0.3 ETH at a rate of 180 USDT per 1 ETH
-  const symbol = 'ETH:USDT'
-  const amount = 0.3
-  const price = 180
-  const validFor = '0'
-  const feeRate = ''
-
-  const submitOrderResponse = await dvf.submitOrder({
-    symbol,
-    amount,
-    price,
-    starkPrivateKey: starkPrivKey,
-    validFor,           // Optional
-    feeRate,            // Optional
-    gid: '1',           // Optional
-    cid: '1',           // Optional
-    partnerId: 'P1'    // Optional
-  })
-
-  console.log('submitOrder response ->', submitOrderResponse)
-  orderId = submitOrderResponse._id
-}
-else {
-  orderId = orders[0]._id
-}
-
-console.log('fetching orderId', orderId)
-
-const response = await dvf.getOrder(orderId)
+const response = await dvf.getOrder(order._id)
 
 logExampleResult(response)

--- a/examples/src/getOrders.js
+++ b/examples/src/getOrders.js
@@ -1,10 +1,8 @@
 const getOrCreateActiveOrder = require('./helpers/getOrCreateActiveOrder')
 
-const symbol = 'ETH:USDT'
-
 // Ensure that there is at least one order to get.
-await getOrCreateActiveOrder(dvf, starkPrivKey, { symbol })
+await getOrCreateActiveOrder(dvf, starkPrivKey)
 
-const getOrdersResponse = await dvf.getOrders(symbol)
+const getOrdersResponse = await dvf.getOrders()
 
 logExampleResult(getOrdersResponse)

--- a/examples/src/getOrders_forSymbolPair.js
+++ b/examples/src/getOrders_forSymbolPair.js
@@ -1,4 +1,3 @@
-
 const symbol = 'BTC:USDT'
 
 let orders = await dvf.getOrders(symbol)
@@ -28,4 +27,4 @@ if (orders.length == 0) {
 
 orders = await dvf.getOrders(symbol)
 
-console.log("getOrders(symbol) response ->", orders)
+logExampleResult(orders)

--- a/examples/src/getVaultId.js
+++ b/examples/src/getVaultId.js
@@ -2,4 +2,4 @@ const token = 'ETH'
 
 const getVaultIdResponse = await dvf.getVaultId(token)
 
-console.log('getVaultId response ->', getVaultIdResponse)
+logExampleResult(getVaultIdResponse)

--- a/examples/src/getWithdrawal.js
+++ b/examples/src/getWithdrawal.js
@@ -22,4 +22,4 @@ else {
 
 const getWithdrawalResponse = await dvf.getWithdrawal(withdrawalId)
 
-console.log('getWithdrawal response ->', getWithdrawalResponse)
+logExampleResult(getWithdrawalResponse)

--- a/examples/src/ledgerDeposit.js
+++ b/examples/src/ledgerDeposit.js
@@ -14,4 +14,4 @@ const depositResponse = await dvf.ledger.deposit(
   starkDepositData
 )
 
-console.log('deposit response ->', depositResponse)
+logExampleResult(depositResponse)

--- a/examples/src/ledgerSubmitOrder.js
+++ b/examples/src/ledgerSubmitOrder.js
@@ -18,4 +18,4 @@ const submitOrderResponse = await dvf.submitOrder({
   partnerId: 'P1'    // Optional
 })
 
-console.log('submitOrder response ->', submitOrderResponse)
+logExampleResult(submitOrderResponse)

--- a/examples/src/ledgerWithdraw.js
+++ b/examples/src/ledgerWithdraw.js
@@ -14,4 +14,4 @@ const withdrawResponse = await dvf.ledger.withdraw(
   starkWithdrawalData
 )
 
-console.log('withdraw response ->', withdrawResponse)
+logExampleResult(withdrawResponse)

--- a/examples/src/register.js
+++ b/examples/src/register.js
@@ -2,4 +2,4 @@ const keyPair = await dvf.stark.createKeyPair(starkPrivKey)
 
 const registerResponse = await dvf.register(keyPair.starkPublicKey)
 
-console.log('register response ->', registerResponse)
+logExampleResult(registerResponse)

--- a/examples/src/submitOrder.js
+++ b/examples/src/submitOrder.js
@@ -23,4 +23,4 @@ const submitOrderResponse = await dvf.submitOrder({
   partnerId: 'P1'    // Optional
 })
 
-console.log('submitOrder response ->', submitOrderResponse)
+logExampleResult(submitOrderResponse)

--- a/examples/src/submitOrder.js
+++ b/examples/src/submitOrder.js
@@ -1,8 +1,8 @@
 const getPriceFromOrderBook = require('./helpers/getPriceFromOrderBook')
 
-// Submit an order to sell 0.3 Eth for 200 USDT per 1 Eth
+// Submit an order to sell 0.1 Eth for USDT
 const symbol = 'ETH:USDT'
-const amount = -0.3
+const amount = -0.1
 const validFor = '0'
 const feeRate = ''
 

--- a/examples/src/withdraw.js
+++ b/examples/src/withdraw.js
@@ -7,4 +7,4 @@ const withdrawalResponse = await dvf.withdraw(
   starkPrivKey
 )
 
-console.log('withdraw response ->', withdrawalResponse)
+logExampleResult(withdrawalResponse)

--- a/examples/src/withdrawOnChain.js
+++ b/examples/src/withdrawOnChain.js
@@ -2,4 +2,4 @@ const token = 'ETH'
 
 const withdrawalResponse = await dvf.withdrawOnchain(token)
 
-console.log('withdraw onchain response ->', withdrawalResponse)
+logExampleResult(withdrawalResponse)

--- a/src/lib/bfx/getTickers.js
+++ b/src/lib/bfx/getTickers.js
@@ -8,6 +8,6 @@ module.exports = async (dvf, symbols) => {
 
   symbols = symbols.map(dvfToBfxSymbol).join(',')
 
-  const response = await get(dvf.config.api + `/bfx/v2/tickers?symbols=${symbols}`)
+  const response = await get((dvf.config.dataApi || dvf.config.api) + `/bfx/v2/tickers?symbols=${symbols}`)
   return JSON.parse(response)
 }


### PR DESCRIPTION
made while comparing responses before/after recent refactor of pub-api

- ensure that examples can be successfully ran in sequence (as it's done
  in [examples/helpers/testExamples.js](/examples/helpers/testExamples.js)
- remove some code duplication
- add option to store example result to file
- respect process.env.CONFIG_FILE_NAME in all examples
- add DATA_API_URL (similar to API_URL) both for end points which call /bfx/v2
- various improvements to examples/00.setup.js
- examples: add src/cancelWithdrawal