### PR TITLE
feat: contract wallet address as an argument on register

### DIFF
--- a/src/api/contract/register.js
+++ b/src/api/contract/register.js
@@ -1,8 +1,9 @@
 const DVFError = require('../../lib/dvf/DVFError')
 const BN = require('bignumber.js')
 
-module.exports = async (dvf, starkKey, deFiSignature) => {
-  const ethAddress = dvf.get('account')
+module.exports = async (dvf, starkKey, deFiSignature, ethAddress) => {
+  ethAddress = ethAddress || dvf.get('account')
+
   const { web3 } = dvf
   const starkInstance = new web3.eth.Contract(
     dvf.contract.abi.getStarkEx(),


### PR DESCRIPTION
Using starkware v2 we can specify which ethAddress we are registering and when we want to register a contract wallet that's not the address that will be on dvf, so we need to specify it