### PR TITLE
Pass nonce and signature to deposit / order submission to avoid unnecessary signing

### DIFF
--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -10,7 +10,7 @@ module.exports = async (dvf, token, amount, starkPrivateKey, nonce, signature) =
   const currency = dvf.token.getTokenInfo(token)
   const quantisedAmount = dvf.token.toQuantizedAmount(token, amount)
   const tempVaultId = dvf.config.DVF.tempStarkVaultId
-  const nonce = dvf.util.generateRandomNonce()
+  const _nonce = dvf.util.generateRandomNonce()
   const starkTokenId = currency.starkTokenId
   const starkVaultId = await dvf.getVaultId(token, nonce, signature)
 
@@ -26,7 +26,7 @@ module.exports = async (dvf, token, amount, starkPrivateKey, nonce, signature) =
   const tradingKey = `0x${starkPublicKey.x}`
   const { starkMessage } = dvf.stark.createTransferMsg(
     quantisedAmount,
-    nonce,
+    _nonce,
     tempVaultId,
     starkTokenId,
     starkVaultId,
@@ -41,7 +41,7 @@ module.exports = async (dvf, token, amount, starkPrivateKey, nonce, signature) =
   const data = {
     token,
     amount,
-    nonce,
+    nonce: _nonce,
     starkPublicKey,
     starkSignature,
     starkVaultId,

--- a/src/api/deposit.js
+++ b/src/api/deposit.js
@@ -2,7 +2,7 @@ const { post } = require('request-promise')
 const DVFError = require('../lib/dvf/DVFError')
 const validateAssertions = require('../lib/validators/validateAssertions')
 
-module.exports = async (dvf, token, amount, starkPrivateKey) => {
+module.exports = async (dvf, token, amount, starkPrivateKey, nonce, signature) => {
   validateAssertions(dvf, { amount, token, starkPrivateKey })
 
   amount = dvf.util.prepareDepositAmount(amount, token)
@@ -12,7 +12,7 @@ module.exports = async (dvf, token, amount, starkPrivateKey) => {
   const tempVaultId = dvf.config.DVF.tempStarkVaultId
   const nonce = dvf.util.generateRandomNonce()
   const starkTokenId = currency.starkTokenId
-  const starkVaultId = await dvf.getVaultId(token)
+  const starkVaultId = await dvf.getVaultId(token, nonce, signature)
 
   const { starkPublicKey, starkKeyPair } = await dvf.stark.createKeyPair(
     starkPrivateKey

--- a/src/api/submitMarketOrder.js
+++ b/src/api/submitMarketOrder.js
@@ -20,7 +20,9 @@ const schema = Joi.object({
   type: Joi.string().default('EXCHANGE MARKET'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
-  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.')
+  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.'),
+  nonce: Joi.string().allow(''),
+  signature: Joi.string().allow('')
 })
 
 module.exports = async (dvf, orderData) => {

--- a/src/api/submitOrder.js
+++ b/src/api/submitOrder.js
@@ -22,7 +22,9 @@ const schema = Joi.object({
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
-  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.')
+  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.'),
+  nonce: Joi.string().allow(''),
+  signature: Joi.string().allow('')
 })
 
 module.exports = async (dvf, orderData) => {

--- a/src/lib/dvf/createMarketOrderPayload.js
+++ b/src/lib/dvf/createMarketOrderPayload.js
@@ -23,7 +23,9 @@ const schema = Joi.object({
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
-  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.')
+  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.'),
+  nonce: Joi.string().allow(''),
+  signature: Joi.string().allow('')
 })
 
 module.exports = async (dvf, orderData) => {

--- a/src/lib/dvf/createOrderPayload.js
+++ b/src/lib/dvf/createOrderPayload.js
@@ -21,7 +21,9 @@ const schema = Joi.object({
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
-  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.')
+  isHidden: Joi.bool().description('Flag to indicate if the order is hidden.'),
+  nonce: Joi.string().allow(''),
+  signature: Joi.string().allow('')
 })
 
 module.exports = async (dvf, orderData) => {

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -4,7 +4,7 @@ const DVFError = require('../dvf/DVFError')
 const computeBuySellData = require('../dvf/computeBuySellData')
 
 
-module.exports = async (dvf, { symbol, amount, price, validFor, feeRate }) => {
+module.exports = async (dvf, { symbol, amount, price, validFor, feeRate, nonce, signature }) => {
   price = preparePriceBN(price)
   amount = preparePriceBN(amount)
 
@@ -22,8 +22,8 @@ module.exports = async (dvf, { symbol, amount, price, validFor, feeRate }) => {
   const buyCurrency = dvf.token.getTokenInfo(buySymbol)
 
   const [vaultIdSell, vaultIdBuy] = await P.join(
-    dvf.getVaultId(sellSymbol),
-    dvf.getVaultId(buySymbol)
+    dvf.getVaultId(sellSymbol, nonce, signature),
+    dvf.getVaultId(buySymbol, nonce, signature)
   )
   if (!(sellCurrency && buyCurrency)) {
     if (!vaultIdSell) {

--- a/src/lib/stark/ledger/createDepositData.js
+++ b/src/lib/stark/ledger/createDepositData.js
@@ -1,7 +1,7 @@
-module.exports = async (dvf, path, token, amount) => {
+module.exports = async (dvf, path, token, amount, nonce, signature) => {
   amount = dvf.util.prepareDepositAmount(amount, token)
   const tempVaultId = dvf.config.DVF.tempStarkVaultId
-  const starkVaultId = await dvf.getVaultId(token)
+  const starkVaultId = await dvf.getVaultId(token, nonce, signature)
 
   const starkDeposit = await dvf.stark.ledger.createSignedTransfer(
     path,


### PR DESCRIPTION
Nonce and signature are passed to getVaultId as a temporary solution for unnecessary nonce signing