### PR TITLE
add depositV2/withdrawalV2 methods

### DIFF
--- a/examples/01.register.js
+++ b/examples/01.register.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/02.deposit.js
+++ b/examples/02.deposit.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/02.depositV2.js
+++ b/examples/02.depositV2.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const HDWalletProvider = require('@truffle/hdwallet-provider')
+const sw = require('starkware_crypto')
+const Web3 = require('web3')
+
+const DVF = require('../src/dvf')
+const envVars = require('./helpers/loadFromEnvOrConfig')(
+  process.env.CONFIG_FILE_NAME
+)
+const logExampleResult = require('./helpers/logExampleResult')(__filename)
+
+const ethPrivKey = envVars.ETH_PRIVATE_KEY
+// NOTE: you can also generate a new key using:`
+// const starkPrivKey = dvf.stark.createPrivateKey()
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
+const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
+
+const provider = new HDWalletProvider(ethPrivKey, infuraURL)
+const web3 = new Web3(provider)
+provider.engine.stop()
+
+const dvfConfig = {
+  api: envVars.API_URL,
+  dataApi: envVars.DATA_API_URL
+  // Add more variables to override default values
+}
+
+;(async () => {
+  const dvf = await DVF(web3, dvfConfig)
+
+  const waitForDepositCreditedOnChain = require('./helpers/waitForDepositCreditedOnChain')
+
+  const depositResponse = await dvf.depositV2({ token: 'USDT', amount: 1 })
+
+  if (process.env.WAIT_FOR_DEPOSIT_READY === 'true') {
+    await waitForDepositCreditedOnChain(dvf, depositResponse)
+  }
+
+  logExampleResult(depositResponse)
+
+})()
+.catch(error => {
+  console.error(error)
+  process.exit(1)
+})
+

--- a/examples/03.getDeposits.js
+++ b/examples/03.getDeposits.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/04.getBalance.js
+++ b/examples/04.getBalance.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/06.getOrders.js
+++ b/examples/06.getOrders.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/07.getOrders_forSymbolPair.js
+++ b/examples/07.getOrders_forSymbolPair.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/09.getConfig.js
+++ b/examples/09.getConfig.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/11.getOrdersHist.js
+++ b/examples/11.getOrdersHist.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/12.getUserConfig.js
+++ b/examples/12.getUserConfig.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/13.withdraw.js
+++ b/examples/13.withdraw.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/14.fastWithdrawal.js
+++ b/examples/14.fastWithdrawal.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/15.getWithdrawals.js
+++ b/examples/15.getWithdrawals.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/16.getWithdrawal.js
+++ b/examples/16.getWithdrawal.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/17.withdrawOnChain.js
+++ b/examples/17.withdrawOnChain.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/18.fullWithdrawalRequest.js
+++ b/examples/18.fullWithdrawalRequest.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/19.getVaultId.js
+++ b/examples/19.getVaultId.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/20.ledgerDeposit.js
+++ b/examples/20.ledgerDeposit.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/21.ledgerSubmitOrder.js
+++ b/examples/21.ledgerSubmitOrder.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/22.ledgerWithdraw.js
+++ b/examples/22.ledgerWithdraw.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/23.cancelWithdrawal.js
+++ b/examples/23.cancelWithdrawal.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/24.authWithTradingKey.js
+++ b/examples/24.authWithTradingKey.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/25.fastWithdrawalFee.js
+++ b/examples/25.fastWithdrawalFee.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/26.fastWithdrawalMaxAmount.js
+++ b/examples/26.fastWithdrawalMaxAmount.js
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/helpers/example.js.tmpl
+++ b/examples/helpers/example.js.tmpl
@@ -13,7 +13,7 @@ const logExampleResult = require('./helpers/logExampleResult')(__filename)
 const ethPrivKey = envVars.ETH_PRIVATE_KEY
 // NOTE: you can also generate a new key using:`
 // const starkPrivKey = dvf.stark.createPrivateKey()
-const starkPrivKey = ethPrivKey
+const starkPrivKey = envVars.STARK_PRIVATE_KEY
 const infuraURL = `https://ropsten.infura.io/v3/${envVars.INFURA_PROJECT_ID}`
 
 const provider = new HDWalletProvider(ethPrivKey, infuraURL)

--- a/examples/helpers/loadFromEnvOrConfig.js
+++ b/examples/helpers/loadFromEnvOrConfig.js
@@ -1,5 +1,5 @@
-fs = require('fs')
-path = require('path')
+const fs = require('fs')
+const path = require('path')
 
 const getConfigVar_ = (config, configFileName) => (varName, defaultValue) => {
   const value = process.env[ varName ] || config[ varName ] || defaultValue
@@ -38,10 +38,12 @@ module.exports = (configFileName = 'config.json') => {
   const getConfigVar = getConfigVar_(config, configFilePath)
 
   const apiUrl = getConfigVar('API_URL', 'https://api.stg.deversifi.com')
+  const ETH_PRIVATE_KEY = getConfigVar('ETH_PRIVATE_KEY')
 
   return {
     INFURA_PROJECT_ID: getConfigVar('INFURA_PROJECT_ID'),
-    ETH_PRIVATE_KEY: getConfigVar('ETH_PRIVATE_KEY'),
+    ETH_PRIVATE_KEY,
+    STARK_PRIVATE_KEY: getConfigVar('STARK_PRIVATE_KEY', ETH_PRIVATE_KEY),
     API_URL: apiUrl,
     DATA_API_URL: getConfigVar('DATA_API_URL', apiUrl)
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "aigle": "git+https://github.com/suguru03/aigle#8739846ba9d4cfc116e1546da1181c73564cae0b",
     "aware": "^0.3.1",
     "bignumber.js": "^9.0.0",
-    "dvf-utils": "git+https://github.com/DeversiFi/dvf-utils#9d0e0da452831430c3358890f220ca2b523aef32",
+    "dvf-utils": "git+https://github.com/DeversiFi/dvf-utils#77692b6e5d45f6051e9263fab209589db145012c",
     "lodash": "^4.17.20",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",

--- a/src/api/contract/approve.js
+++ b/src/api/contract/approve.js
@@ -2,49 +2,62 @@
  * Approves a token for locking
  *
  */
+const { BN, toBN } = require('dvf-utils')
+
+const maxAmountBN = BN(2).pow(96).minus(1)
+
+const validateDepositAmountAndConvertToBN = amount => {
+  const amountBN = toBN(amount)
+  if (amountBN.isLessThanOrEqualTo(0)) {
+    throw new Error('deposit amount should be >= 0')
+  }
+
+  if (!amountBN.isInteger()) {
+    throw new Error('deposit amount should be >= 0')
+  }
+
+  return amountBN
+}
+
+const tokensWhichNeedResetToZero = ['USDT', 'OMG']
+
 module.exports = async (dvf, token, deposit) => {
   if (token === 'ETH') {
+    // TODO: This code is not very safe if caller expects the result to be of
+    // the shape returned by dvf.eth.send below.
     return true
   }
 
-  const currency = dvf.token.getTokenInfo(token)
+  const depositBN = deposit == null
+    ? maxAmountBN
+    : validateDepositAmountAndConvertToBN(deposit)
 
-  const maxAmount = (2 ** 96 - 1).toString(16)
+  const allowance = await dvf.contract.isApproved(token)
 
-  if (!deposit) {
-    deposit = maxAmount
-  }
+  const allowanceBN = toBN(allowance)
 
-  const allowance = parseInt(await dvf.contract.isApproved(token))
-
-  const action = 'approve'
-
-  if (allowance > deposit) {
+  if (allowanceBN.isGreaterThanOrEqualTo(depositBN)) {
+    // As above
     return true
   }
 
-  if (token === 'USDT' && allowance !== 0) {
-    const args = [
-      dvf.config.DVF.starkExContractAddress, // address _spender
-      0
-    ]
-    await dvf.eth.send(
-      dvf.contract.abi.token,
-      currency.tokenAddress,
-      action,
-      args
-    )
-  }
+  const tokenInfo = dvf.token.getTokenInfoOrThrow(token)
 
-  const args = [
-    dvf.config.DVF.starkExContractAddress, // address _spender
-    maxAmount // uint amount
-  ]
-
-  return dvf.eth.send(
+  const approve = amount => dvf.eth.send(
     dvf.contract.abi.token,
-    currency.tokenAddress,
-    action,
-    args
+    tokenInfo.tokenAddress,
+    'approve',
+    [
+      dvf.config.DVF.starkExContractAddress, // address _spender
+      amount
+    ]
   )
+
+  // For some tokens, the amount needs to be reset to 0 before setting it to
+  // a new (non-zero) value.
+  if (tokensWhichNeedResetToZero.includes(token) && !allowanceBN.isZero()) {
+    await approve(0)
+  }
+
+  return approve(maxAmountBN.toString())
 }

--- a/src/api/contract/deposit.js
+++ b/src/api/contract/deposit.js
@@ -1,3 +1,5 @@
+const errorReasons = require('../../lib/dvf/errorReasons')
+
 module.exports = async (dvf, vaultId, token, amount, tradingKey) => {
   let value
   tradingKey = tradingKey || dvf.config.starkKeyHex
@@ -31,10 +33,13 @@ module.exports = async (dvf, vaultId, token, amount, tradingKey) => {
       args
     )
   } catch (e) {
+    // TODO: why are we not simply throwing here? We are not awaiting the send
+    // so the error could only be caused by a bug in the block above but not
+    // actual execution of the contract method (since it's async).
     if (!dvf.contract.isApproved(token)) {
       return {
         error: 'ERR_CORE_ETHFX_NEEDS_APPROVAL',
-        reason: reasons.ERR_CORE_ETHFX_NEEDS_APPROVAL.trim(),
+        reason: errorReasons.ERR_CORE_ETHFX_NEEDS_APPROVAL.trim(),
         originalError: e
       }
     } else {

--- a/src/api/contract/depositFromStarkTx.js
+++ b/src/api/contract/depositFromStarkTx.js
@@ -1,0 +1,24 @@
+// TODO: this file contains very similar logic to ./deposit, so one could be
+// implemented in terms of the other once the TODO in the latter is resolved.
+const sendToStarkExContract = require('./sendToStarkExContract')
+
+const { fromQuantizedToBaseUnitsBN } = require('dvf-utils')
+
+module.exports = (dvf, { starkKey, tokenId, vaultId, amount }) => {
+  const ethTokenInfo = dvf.token.getTokenInfoOrThrow('ETH')
+
+  // This should never happen.
+  if (!ethTokenInfo.starkTokenId) {
+    throw new Error('ethTokenInfo.starkTokenId not defined')
+  }
+
+  const methodArgs = [starkKey, tokenId, vaultId]
+  const sendArgs = tokenId === ethTokenInfo.starkTokenId
+    // For ETH, we convert amount to WEI and add as extra send arg
+    ? [methodArgs, fromQuantizedToBaseUnitsBN(ethTokenInfo, amount).toString()]
+    // For other tokens, use amount as is (should be quantised), and add to
+    // method args.
+    : [methodArgs.concat(amount.toString())]
+
+  return sendToStarkExContract(dvf)('deposit')(sendArgs)
+}

--- a/src/api/contract/sendToStarkExContract.js
+++ b/src/api/contract/sendToStarkExContract.js
@@ -1,0 +1,6 @@
+module.exports = dvf => action => (sendArgsArray = []) => dvf.eth.send(
+  dvf.contract.abi.getStarkEx(),
+  dvf.config.DVF.starkExContractAddress,
+  action,
+  ...sendArgsArray
+)

--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -1,0 +1,30 @@
+const DVFError = require('../lib/dvf/DVFError')
+
+const { fromQuantizedToBaseUnitsBN } = require('dvf-utils')
+
+const postDeposit = require('../lib/dvf/makeDepositOrWithdrawV2ApiMethod')('deposit')
+const contractDepositFromStarkTx = require('./contract/depositFromStarkTx')
+
+module.exports = async (dvf, data, nonce, signature) => {
+  const httpDeposit = await postDeposit(dvf, data, nonce, signature)
+
+  const { token, tx } = httpDeposit
+
+  const tokenInfo = dvf.token.getTokenInfoOrThrow(token)
+
+  await dvf.contract.approve(
+    token,
+    fromQuantizedToBaseUnitsBN(tokenInfo, tx.amount).toString()
+  )
+
+  const onChainDeposit = await contractDepositFromStarkTx(dvf, tx)
+
+  if (!onChainDeposit.status) {
+    throw new DVFError('ERR_ONCHAIN_DEPOSIT', {
+      httpDeposit,
+      onChainDeposit
+    })
+  }
+
+  return { ...httpDeposit, transactionHash: onChainDeposit.transactionHash }
+}

--- a/src/api/withdrawalV2.js
+++ b/src/api/withdrawalV2.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/dvf/makeDepositOrWithdrawV2ApiMethod')('withdrawal')

--- a/src/lib/dvf/addAuthHeadersOrData.js
+++ b/src/lib/dvf/addAuthHeadersOrData.js
@@ -1,13 +1,20 @@
 const makeAuthHeaders = require('./makeAuthHeaders')
 
 module.exports = async (dvf, nonce, signature, { headers = {}, data = {} }) => {
-  if (dvf.config.useTradingKey || dvf.config.useSignature) {
+  if (
+    // if any of these is set, don't generated nonce/signature as they are
+    // expected to be passed in by the caller.
+    // TODO: change this, so that nonce/signature can always be generated
+    // automatically and is cached on the clients state.
+    !dvf.config.useTradingKey && !dvf.config.useSignature &&
+    (nonce == null || !signature)
+  ) {
+    ({ nonce, signature } = await dvf.sign.nonceSignature(nonce, signature))
+  }
+
+  if (dvf.config.useAuthHeader || dvf.config.useTradingKey || dvf.config.useSignature) {
     headers = { ...headers, ...makeAuthHeaders(dvf, nonce, signature) }
   } else {
-    if (!nonce || !signature) {
-      ({ nonce, signature } = await dvf.sign.nonceSignature(nonce, signature))
-    }
-
     data = { ...data, nonce, signature }
   }
 

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -164,6 +164,7 @@ module.exports = () => {
   dvf.getWithdrawal = compose(require('../../api/getWithdrawal'))
   dvf.getWithdrawals = compose(require('../../api/getWithdrawals'))
   dvf.withdraw = compose(require('../../api/withdraw'))
+  dvf.withdrawalV2 = compose(require('../../api/withdrawalV2'))
   dvf.withdrawOnchain = compose(require('../../api/withdrawOnchain'))
   dvf.fullWithdrawalRequest = compose(require('../../api/fullWithdrawalRequest'))
   dvf.ledger = {

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -138,6 +138,7 @@ module.exports = () => {
   dvf.cancelOrder = compose(require('../../api/cancelOrder'))
   dvf.cancelWithdrawal = compose(require('../../api/cancelWithdrawal'))
   dvf.deposit = compose(require('../../api/deposit'))
+  dvf.depositV2 = compose(require('../../api/depositV2'))
   dvf.fastWithdrawal = compose(require('../../api/fastWithdrawal'))
   dvf.fastWithdrawalFee = compose(require('../../api/fastWithdrawalFee'))
   dvf.fastWithdrawalMaxAmount = compose(require('../../api/fastWithdrawalMaxAmount'))

--- a/src/lib/dvf/generateRandomNonceV2.js
+++ b/src/lib/dvf/generateRandomNonceV2.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return Math.ceil(Math.random() * Number.MAX_SAFE_INTEGER)
+}

--- a/src/lib/dvf/makeDepositOrWithdrawV2ApiMethod.js
+++ b/src/lib/dvf/makeDepositOrWithdrawV2ApiMethod.js
@@ -1,0 +1,62 @@
+const FP = require('lodash/fp')
+const { Joi, Long, toQuantizedAmountBN, fromQuantizedToBaseUnitsBN } = require('dvf-utils')
+
+const post = require('./post-authenticated')
+
+const generateRandomNonceV2 = require('./generateRandomNonceV2')
+const validateWithJoi = require('../validators/validateWithJoi')
+
+const schema = Joi.object({
+  token: Joi.string(),
+  // This is base unit amount.
+  amount: Joi.bigNumber().greaterThan(0),
+  nonce: Joi.number().integer()
+    .min(0)
+    // Will be auto-generated if not provided.
+    .optional()
+})
+
+module.exports = type => {
+  if (!['deposit', 'withdrawal'].includes(type)) {
+    throw new Error(`unexpected type ${type}`)
+  }
+
+  const validateArg0 = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({
+    context: `${type}V2`,
+    argIdx: 0
+  })
+
+  const endpoint = `/v1/trading/${type}s`
+
+  return (dvf, data, authNonce, signature) => {
+    const validData = validateArg0(data)
+    const { token, amount: baseUnitAmount } = validData
+
+    const tokenInfo = dvf.token.getTokenInfoOrThrow(token)
+    const quantisedAmount = toQuantizedAmountBN(tokenInfo, baseUnitAmount)
+
+    if (quantisedAmount.isLessThan(1)) {
+      throw new Error(
+        `${type} amount too small, got: ${baseUnitAmount}, allowed minumum: ` +
+        `${fromQuantizedToBaseUnitsBN(tokenInfo, 1)}`
+      )
+    }
+
+    if (quantisedAmount.isGreaterThan(Long.MAX_VALUE)) {
+      throw new Error(
+        `${type} amount too large, got: ${baseUnitAmount} allowed minumum: ` +
+        `${fromQuantizedToBaseUnitsBN(tokenInfo, Long.MAX_VALUE)}`
+      )
+    }
+
+    const nonce = validData.nonce != null
+      ? validData.nonce
+      : generateRandomNonceV2()
+
+    const payload = { token, amount: quantisedAmount, nonce }
+
+    // Force the use of header (instead of payload) for authentication.
+    dvf = FP.set('config.useAuthHeader', true, dvf)
+    return post(dvf, endpoint, authNonce, signature, payload)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+bson@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.5.tgz#2aaae98fcdf6750c0848b0cba1ddec3c73060a34"
+  integrity sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==
+
 btoa@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
@@ -3164,12 +3169,13 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-"dvf-utils@git+https://github.com/DeversiFi/dvf-utils#9d0e0da452831430c3358890f220ca2b523aef32":
-  version "0.2.2"
-  resolved "git+https://github.com/DeversiFi/dvf-utils#9d0e0da452831430c3358890f220ca2b523aef32"
+"dvf-utils@git+https://github.com/DeversiFi/dvf-utils#77692b6e5d45f6051e9263fab209589db145012c":
+  version "0.2.4"
+  resolved "git+https://github.com/DeversiFi/dvf-utils#77692b6e5d45f6051e9263fab209589db145012c"
   dependencies:
     "@hapi/joi" "^17.1.1"
     bignumber.js "^9.0.0"
+    bson "^1.1.5"
     ramda "^0.27.1"
     web3-utils "^1.3.0"
 


### PR DESCRIPTION
which can be called as follows:

```js
await dvf.depositV2({ token: 'USDT', amount: 1 })
await dvf.withdrawalV2({ token: 'USDT', amount: 1 })
```

also:
- addAuthHeadersOrData: add useAuthHeader options, which causes authentication
  to always be done via header (the above method force this behaviour since
  corresponding backend end points do not accept auth on payload).
  This can also be set for all method by setting `dvf.config.useAuthHeader = true`.
- examples: allow setting starkPrivateKey via env var / config (`STARK_PRIVATE_KEY`)
- src/api/contract/approve: fix numeric precision issues and add OMG handling
- src/api/contract/deposit.js: fix undefined `reasons` and add TODO