### PR TITLE
depositV2: client-side tx generation

### DIFF
--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -1,30 +1,38 @@
 const DVFError = require('../lib/dvf/DVFError')
 
-const { fromQuantizedToBaseUnitsBN } = require('dvf-utils')
+const { fromQuantizedToBaseUnitsBN, toQuantizedAmountBN } = require('dvf-utils')
 
-const postDeposit = require('../lib/dvf/makeDepositOrWithdrawV2ApiMethod')('deposit')
 const contractDepositFromStarkTx = require('./contract/depositFromStarkTx')
+const getVaultId = require('./getVaultId')
+const validateAssertions = require('../lib/validators/validateAssertions')
 
-module.exports = async (dvf, data, nonce, signature) => {
-  const httpDeposit = await postDeposit(dvf, data, nonce, signature)
-
-  const { token, tx } = httpDeposit
+module.exports = async (dvf, { token, amount }, nonce, signature) => {
+  validateAssertions(dvf, { token, amount })
 
   const tokenInfo = dvf.token.getTokenInfoOrThrow(token)
+  const quantisedAmount = toQuantizedAmountBN(tokenInfo, amount)
+  const vaultId = await getVaultId(dvf, token, nonce, signature)
+
+  const { starkKeyHex } = dvf.config
+  const tx = {
+    vaultId,
+    tokenId: tokenInfo.starkTokenId,
+    starkKey: starkKeyHex,
+    amount: quantisedAmount
+  }
 
   await dvf.contract.approve(
     token,
-    fromQuantizedToBaseUnitsBN(tokenInfo, tx.amount).toString()
+    fromQuantizedToBaseUnitsBN(tokenInfo, quantisedAmount).toString()
   )
 
   const onChainDeposit = await contractDepositFromStarkTx(dvf, tx)
 
   if (!onChainDeposit.status) {
     throw new DVFError('ERR_ONCHAIN_DEPOSIT', {
-      httpDeposit,
       onChainDeposit
     })
   }
 
-  return { ...httpDeposit, transactionHash: onChainDeposit.transactionHash }
+  return { transactionHash: onChainDeposit.transactionHash }
 }


### PR DESCRIPTION
For depositV2, we now generate the Ethereum transaction on client-side (we just ask the server for a vaultId).

Eyes only (not to merge now) as waiting for backend PR