### PR TITLE
depositV2: transactioHashCallback to propagate err

### DIFF
--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -49,8 +49,14 @@ module.exports = async (dvf, data, nonce, signature) => {
   // event without changing the return signatures of the underlying 'send'
   // More : https://github.com/ChainSafe/web3.js/issues/1547
   let transactionHashCb
-  const transactionHashPromise = new Promise(resolve => {
-    transactionHashCb = resolve
+  const transactionHashPromise = new Promise((resolve, reject) => {
+    transactionHashCb = (err, result) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(result)
+      }
+    }
   })
 
   const onChainDepositPromise = contractDepositFromStarkTx(dvf, tx, {transactionHashCb})

--- a/src/api/eth/send.js
+++ b/src/api/eth/send.js
@@ -25,7 +25,11 @@ module.exports = async (dvf, abi, address, action, args, value, options = {}) =>
 
   const txPromEvent = method.send(sendOptions)
   if (options.transactionHashCb) {
-    txPromEvent.on('transactionHash', options.transactionHashCb)
+    txPromEvent.on('transactionHash', (txHash) => options.transactionHashCb(null, txHash))
+    txPromEvent.catch(error => {
+      options.transactionHashCb(error)
+      throw error
+    })
   }
   return txPromEvent
 }


### PR DESCRIPTION
Related to https://app.asana.com/0/1165477653959782/1199968011428762/f

`transactionHashCb` callback to behave like a standard callback and have error as first argument (making the wrapper promise reject in case of error rather than never resolve)