### PR TITLE
fix: prepareAmountBN in createOrder for amount

### DIFF
--- a/src/api/submitOrder.test.js
+++ b/src/api/submitOrder.test.js
@@ -124,7 +124,7 @@ describe('dvf.submitOrder', () => {
   it('Forces 5 significant digits on price and 8 decimal places on amount', async () => {
     mockGetConf()
     const symbol = 'ZRX:ETH'
-    const amount = -55.000000001
+    const amount = -55.123456789
     const price = 12.3456
     const validFor = '0'
 
@@ -136,7 +136,7 @@ describe('dvf.submitOrder', () => {
       gid: '',
       type: 'EXCHANGE LIMIT',
       symbol,
-      amount: '-55.00000001',
+      amount: '-55.12345679',
       price: '12.346',
       feeRate: 0.0025,
       protocol: 'stark',

--- a/src/lib/stark/createOrder.js
+++ b/src/lib/stark/createOrder.js
@@ -3,10 +3,9 @@ const { preparePriceBN, prepareAmountBN, splitSymbol } = require('dvf-utils')
 const DVFError = require('../dvf/DVFError')
 const computeBuySellData = require('../dvf/computeBuySellData')
 
-
 module.exports = async (dvf, { symbol, amount, price, validFor, feeRate, nonce, signature }) => {
   price = preparePriceBN(price)
-  amount = preparePriceBN(amount)
+  amount = prepareAmountBN(amount)
 
   feeRate = parseFloat(feeRate) || dvf.config.DVF.defaultFeeRate
 


### PR DESCRIPTION
Related to https://app.asana.com/0/1165477653959782/1199973419266868/f

In `dvf-client-js` > `createOrder` function amount was rounded using a price rounding function instead of amount rounding function.
Switching to amount rounding function.

**/!\** Note that I couldn't measure the impact of this, as from the portal the amounts are rounded the same way regardless of this change (maybe because of some priori UI-side rounding).