### PR TITLE
authentication: nonce replaced by message signing

### DIFF
--- a/src/api/sign/nonceSignature.js
+++ b/src/api/sign/nonceSignature.js
@@ -1,17 +1,16 @@
+const { makeGenerateAuthMessage } = require('dvf-utils')
 /**
- *
- * if either nonce and signature are not provided a
- * new nonce and signature are created. if nonce and
- * signature were provided the same are returned back
- *
+ * if either message and signature are not provided a
+ * new nonce/message and signature are created. if nonce
+ * and signature were provided the same are returned back
  */
-
 module.exports = async (dvf, nonce, signature) => {
   if (!(nonce && signature)) {
     nonce = Date.now() / 1000
-    signature = await dvf.sign(String(nonce).toString(16))
+    const authVersion = dvf.config.DVF.authVersion || 1
+    const message = makeGenerateAuthMessage(authVersion)(nonce)
+    signature = await dvf.sign(message)
   }
 
-  
   return {nonce, signature}
 }

--- a/src/api/sign/sign.js
+++ b/src/api/sign/sign.js
@@ -11,7 +11,7 @@ module.exports = async (dvf, toSign, signWithStarkProvider) => {
   if (dvf.web3.currentProvider.isMetaMask) {
     return dvf.web3.eth.personal.sign(toSign, dvf.get('account'))
   } else if (signWithStarkProvider) {
-    return dvf.config.starkProvider.signNonce(toSign)
+    return dvf.config.starkProvider.starkSignMessage(toSign)
   } else {
     return dvf.web3.eth.sign(toSign, dvf.get('account'))
   }


### PR DESCRIPTION
Related to https://app.asana.com/0/1165477653959782/1200001482815220/f

Signs nonce like before until `authVersion` is added to server `getConf` response and will start signing message instead