### PR TITLE
getBalance to accept arbitrary params as payload

### DIFF
--- a/src/api/getBalance.js
+++ b/src/api/getBalance.js
@@ -2,15 +2,20 @@ const validateAssertions = require('../lib/validators/validateAssertions')
 
 const post = require('../lib/dvf/post-authenticated')
 
-module.exports = async (dvf, token, nonce, signature) => {
-  if (token) {
-    validateAssertions(dvf, {token})
+/*
+  params: {
+    token: 'ETH', (optional)
+    fields: ['balance', 'updatedAt'] (optional)
+  }
+*/
+module.exports = async (dvf, params, nonce, signature) => {
+  if (params) {
+    validateAssertions(dvf, params)
   }
 
   const endpoint = '/v1/trading/r/getBalance'
 
-  const data = {token}
+  const data = params
 
   return post(dvf, endpoint, nonce, signature, data)
 }
-

--- a/src/api/getBalance.test.js
+++ b/src/api/getBalance.test.js
@@ -29,7 +29,7 @@ describe('dvf.getBalance', () => {
       })
       .reply(200, apiResponse)
 
-    const balance = await dvf.getBalance('ETH', nonce, signature)
+    const balance = await dvf.getBalance({token: 'ETH'}, nonce, signature)
     expect(balance).toEqual(apiResponse)
   })
 
@@ -69,7 +69,7 @@ describe('dvf.getBalance', () => {
       .reply(422, apiErrorResponse)
 
     try {
-      await dvf.getBalance('ETH', nonce, signature)
+      await dvf.getBalance({token: 'ETH'}, nonce, signature)
     } catch (e) {
       expect(e.error).toEqual(apiErrorResponse)
     }


### PR DESCRIPTION
Related to : https://app.asana.com/0/1165477653959782/1199992925843663/f

`getBalance` endpoint accepting `params` instead of just `token` (adding extra `fields` optional param)