### PR TITLE
Feat/order generic meta feature

### DIFF
--- a/src/api/submitMarketOrder.js
+++ b/src/api/submitMarketOrder.js
@@ -17,6 +17,7 @@ const schema = Joi.object({
   gid: Joi.string().allow(''),
   partnerId: Joi.string().allow(''),
   ethAddress: Joi.string().pattern(/[\da-f]/i),
+  feature: Joi.string().default('UNKNOWN'), // Tracks order origin (ex: 'TRADING', 'SWAP')
   type: Joi.string().default('EXCHANGE MARKET'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),

--- a/src/api/submitOrder.js
+++ b/src/api/submitOrder.js
@@ -6,7 +6,6 @@ Keeping the schema visible and not in a seperate method
 for reference as required parameters can be checked by reading
 */
 
-
 const schema = Joi.object({
   symbol: Joi.string().required(), // trading symbol
   amount: Joi.amount().required(), // number or number string
@@ -19,6 +18,7 @@ const schema = Joi.object({
   gid: Joi.string().allow(''),
   partnerId: Joi.string().allow(''),
   ethAddress: Joi.string().pattern(/[\da-f]/i),
+  feature: Joi.string().default('UNKNOWN'), // Tracks order origin (ex: 'TRADING', 'SWAP')
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),

--- a/src/lib/dvf/createMarketOrderPayload.js
+++ b/src/lib/dvf/createMarketOrderPayload.js
@@ -20,6 +20,7 @@ const schema = Joi.object({
   gid: Joi.string().allow(''),
   partnerId: Joi.string().allow(''),
   ethAddress: Joi.string().pattern(/[\da-f]/i),
+  feature: Joi.string().default('UNKNOWN'), // Tracks order origin (ex: 'TRADING', 'SWAP')
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
@@ -66,6 +67,7 @@ module.exports = async (dvf, orderData) => {
     ),
     meta: {
       ethAddress,
+      feature: finalValue.feature,
       ...(await dvf.createMarketOrderMetaData(finalValue))
     }
   }

--- a/src/lib/dvf/createOrderPayload.js
+++ b/src/lib/dvf/createOrderPayload.js
@@ -18,6 +18,7 @@ const schema = Joi.object({
   gid: Joi.string().allow(''),
   partnerId: Joi.string().allow(''),
   ethAddress: Joi.string().pattern(/[\da-f]/i),
+  feature: Joi.string().default('UNKNOWN'), // Tracks order origin (ex: 'TRADING', 'SWAP')
   type: Joi.any().default('EXCHANGE LIMIT'),
   protocol: Joi.any().default('stark'),
   isPostOnly: Joi.bool().description('Flag to indicate if the order is post-only.'),
@@ -56,6 +57,7 @@ module.exports = async (dvf, orderData) => {
     ),
     meta: {
       ethAddress,
+      feature: value.feature,
       ...(await dvf.createOrderMetaData(value))
     }
   }


### PR DESCRIPTION
Related to https://app.asana.com/0/1165477653959782/1200060607547442/f

Adds an optional "feature" field to order submission API.
Will record where an order originated from : `TRADING`, `TWAP`, `SWAP`, `YIELD`, ...

