### PR TITLE
orders: allow to use orderId or cid for get/cancel

### DIFF
--- a/examples/05.submitOrder.js
+++ b/examples/05.submitOrder.js
@@ -50,7 +50,7 @@ const dvfConfig = {
     validFor,           // Optional
     feeRate,            // Optional
     gid: '1',           // Optional
-    cid: '1',           // Optional
+    cid: 'mycid-' + Math.random().toString(36).substring(7), // Optional
     partnerId: 'P1'    // Optional
   })
 

--- a/examples/08.cancelOrder.js
+++ b/examples/08.cancelOrder.js
@@ -53,7 +53,7 @@ const dvfConfig = {
       validFor,           // Optional
       feeRate,            // Optional
       gid: '1',           // Optional
-      cid: '1',           // Optional
+      cid: 'mycid-cancel-example',           // Optional
       partnerId: 'P1'    // Optional
     })
 
@@ -74,6 +74,8 @@ const dvfConfig = {
   console.log('cancelling orderId', orderId)
 
   const response = await dvf.cancelOrder(orderId)
+  // Alternative with cid :
+  // const response = await dvf.cancelOrder({cid: 'mycid-cancel-example'})
 
   logExampleResult(response)
 

--- a/examples/10.getOrder.js
+++ b/examples/10.getOrder.js
@@ -33,9 +33,16 @@ const dvfConfig = {
 
   const order = await getOrCreateActiveOrder(dvf, starkPrivKey)
 
-  const response = await dvf.getOrder(order._id)
+  {
+    const response = await dvf.getOrder(order._id)
+    logExampleResult(response)
+  }
 
-  logExampleResult(response)
+  {
+    // Alternative using cid :
+    const response = await dvf.getOrder({cid: order.cid})
+    logExampleResult(response)
+  }
 
 })()
 .catch(error => {

--- a/src/api/cancelOrder.js
+++ b/src/api/cancelOrder.js
@@ -1,13 +1,19 @@
 const post = require('../lib/dvf/post-authenticated')
+const extractOrderIdsInput = require('../lib/util/extractOrderIdsInput')
 
 const validateAssertions = require('../lib/validators/validateAssertions')
 
-module.exports = async (dvf, orderId, nonce, signature) => {
-  validateAssertions(dvf, {orderId })
+/**
+ *
+ * @param {Object} orderIdOrCid 'xxx' or { orderId: 'xxx' } or { cid: 'yyy' }
+ */
+module.exports = async (dvf, orderIdOrCid, nonce, signature) => {
+  const input = extractOrderIdsInput(orderIdOrCid)
+  validateAssertions(dvf, input)
 
   const endpoint = '/v1/trading/w/cancelOrder'
 
-  const data = {orderId}
+  const data = input
 
   return post(dvf, endpoint, nonce, signature, data)
 }

--- a/src/api/cancelOrder.test.js
+++ b/src/api/cancelOrder.test.js
@@ -23,7 +23,7 @@ describe('dvf.cancelOrder', () => {
     const payloadValidator = jest.fn(body => {
       expect(body.orderId).toBe(orderId)
       expect(typeof body.orderId).toBe('string')
-      expect(typeof body.nonce).toBe('number')
+      expect(typeof body.nonce).toBe('string')
       expect(typeof body.signature).toBe('string')
 
       return true
@@ -34,6 +34,30 @@ describe('dvf.cancelOrder', () => {
       .reply(200, apiResponse)
 
     const response = await dvf.cancelOrder(orderId)
+
+    expect(payloadValidator).toBeCalled()
+
+    expect(response).toEqual(apiResponse)
+  })
+
+  it('Posts to cancel order API with { cid } and gets response', async () => {
+    const cid = 'cid-1'
+    const apiResponse = { cancelOrder: 'success' }
+
+    const payloadValidator = jest.fn(body => {
+      expect(body.cid).toBe(cid)
+      expect(typeof body.cid).toBe('string')
+      expect(typeof body.nonce).toBe('string')
+      expect(typeof body.signature).toBe('string')
+
+      return true
+    })
+
+    nock(dvf.config.api)
+      .post('/v1/trading/w/cancelOrder', payloadValidator)
+      .reply(200, apiResponse)
+
+    const response = await dvf.cancelOrder({ cid })
 
     expect(payloadValidator).toBeCalled()
 

--- a/src/api/getOrder.js
+++ b/src/api/getOrder.js
@@ -1,13 +1,19 @@
 const post = require('../lib/dvf/post-authenticated')
+const extractOrderIdsInput = require('../lib/util/extractOrderIdsInput')
 
 const validateAssertions = require('../lib/validators/validateAssertions')
 
-module.exports = async (dvf, orderId, nonce, signature) => {
-  validateAssertions(dvf, {orderId })
+/**
+ *
+ * @param {Object} orderIdOrCid 'xxx' or { orderId: 'xxx' } or { cid: 'yyy' }
+ */
+module.exports = async (dvf, orderIdOrCid, nonce, signature) => {
+  const input = extractOrderIdsInput(orderIdOrCid)
+  validateAssertions(dvf, input)
 
   const endpoint = '/v1/trading/r/getOrder'
 
-  const data = {orderId}
+  const data = input
 
   return post(dvf, endpoint, nonce, signature, data)
 }

--- a/src/api/getOrder.test.js
+++ b/src/api/getOrder.test.js
@@ -34,7 +34,28 @@ describe('dvf.getOrder', () => {
     expect(response).toEqual(apiResponse)
   })
 
-  it('getOrder checks for orderId....', async () => {
+  it('Posts to get order API with { cid } and gets response', async () => {
+    const cid = 'cid-1'
+    const apiResponse = { cancelOrder: 'success' }
+
+    const payloadValidator = jest.fn(body => {
+      expect(body.cid).toBe(cid)
+      expect(typeof body.cid).toBe('string')
+      return true
+    })
+
+    nock(dvf.config.api)
+      .post('/v1/trading/r/getOrder', payloadValidator)
+      .reply(200, apiResponse)
+
+    const response = await dvf.getOrder({ cid })
+
+    expect(payloadValidator).toBeCalled()
+
+    expect(response).toEqual(apiResponse)
+  })
+
+  it('getOrder checks for orderId or cid....', async () => {
     try {
       await dvf.getOrder(null)
 

--- a/src/lib/util/extractOrderIdsInput.js
+++ b/src/lib/util/extractOrderIdsInput.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {Object} orderIdOrCid 'xxx' or { orderId: 'xxx' } or { cid: 'yyy' }
+ */
+module.exports = orderIdOrCid => {
+  if (typeof orderIdOrCid === 'object' && orderIdOrCid !== null) {
+    const { cid, orderId } = orderIdOrCid
+    return cid ? { cid } : { orderId }
+  } else {
+    // Supporting input to be orderId as original behavior
+    return { orderId: orderIdOrCid }
+  }
+}

--- a/src/lib/validators/cid.js
+++ b/src/lib/validators/cid.js
@@ -1,0 +1,7 @@
+const DVFError = require('../dvf/DVFError')
+
+module.exports = (dvf, cid) => {
+  if (!cid) {
+    throw new DVFError('ERR_INVALID_CID')
+  }
+}

--- a/src/lib/validators/validateAssertions.js
+++ b/src/lib/validators/validateAssertions.js
@@ -1,6 +1,7 @@
 const validators = {
   id: require('./id'),
   orderId: require('./orderId'),
+  cid: require('./cid'),
   symbol: require('./symbol'),
   token: require('./token'),
   nonce: require('./nonce'),


### PR DESCRIPTION
Related to : https://app.asana.com/0/1165477653959782/1200105839681745/f

Retrocompatible addition to enable `{cid: 'yyy'}`, {orderId: 'xxx'}` or `'xxx'` to be passed as input for `getOrder` and `cancelOrder`