### PR TITLE
validateWithJoi: fields required by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2021-30-03
+### Fixed
+- Schema validated using `validateWithJoi` to be `required()` by default
+
 ## 2.0.0 - 2021-30-03
 ### Changed
 - `dvf.transfer` method signature changes : `starkPrivateKey` to be set via configuration instead of input argument - see `examples/27.transfer.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",

--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -12,8 +12,8 @@ const getSafeQuantizedAmountOrThrow = require('../lib/dvf/token/getSafeQuantized
 
 const schema = Joi.object({
   token: Joi.string(),
-  amount: Joi.bigNumber().greaterThan(0).required(), // number or number string
-  useProxiedContract: Joi.boolean().default(false)
+  amount: Joi.bigNumber().greaterThan(0), // number or number string
+  useProxiedContract: Joi.boolean().optional().default(false)
 })
 
 const validateArg0 = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({

--- a/src/api/registerAndDeposit.js
+++ b/src/api/registerAndDeposit.js
@@ -10,7 +10,7 @@ const getSafeQuantizedAmountOrThrow = require('../lib/dvf/token/getSafeQuantized
 
 const schema = Joi.object({
   token: Joi.string(),
-  amount: Joi.bigNumber().greaterThan(0).required() // number or number string
+  amount: Joi.bigNumber().greaterThan(0) // number or number string
 })
 
 const validateArg0 = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({

--- a/src/api/withdrawV2.js
+++ b/src/api/withdrawV2.js
@@ -9,7 +9,7 @@ const getSafeQuantizedAmountOrThrow = require('../lib/dvf/token/getSafeQuantized
 
 const schema = Joi.object({
   token: Joi.string(),
-  amount: Joi.bigNumber().greaterThan(0).required(), // number or number string
+  amount: Joi.bigNumber().greaterThan(0), // number or number string
   nonce: Joi.number().integer()
     .min(0)
     // Will be auto-generated if not provided.

--- a/src/lib/dvf/createFastWithdrawalPayload.js
+++ b/src/lib/dvf/createFastWithdrawalPayload.js
@@ -38,11 +38,11 @@ const getFeeQuantised = async (dvf, token) => dvf
   .then(res => toBN(res.feeQuantised))
 
 const schema = Joi.object({
-  amount: Joi.amount().required(),
+  amount: Joi.amount(),
   // NOTE: we are not specifying allowed tokens here since these can change
   // dynamically. However a call to `getTokenInfoOrThrow` will ensure that
   // the token in valid.
-  token: Joi.string().required(),
+  token: Joi.string(),
   // TODO: create Joi.ethAddress
   recipientEthAddress: Joi.string().optional(),
   transactionFee: Joi.alternatives()

--- a/src/lib/stark/ledger/createFastWithdrawalPayload.js
+++ b/src/lib/stark/ledger/createFastWithdrawalPayload.js
@@ -45,11 +45,11 @@ const getFeeQuantised = async (dvf, token) => dvf
   .then(res => toBN(res.feeQuantised))
 
 const schema = Joi.object({
-  amount: Joi.amount().required(),
+  amount: Joi.amount(),
   // NOTE: we are not specifying allowed tokens here since these can change
   // dynamically. However a call to `getTokenInfoOrThrow` will ensure that
   // the token in valid.
-  token: Joi.string().required(),
+  token: Joi.string(),
   // TODO: create Joi.ethAddress
   recipientEthAddress: Joi.string().optional()
 })

--- a/src/lib/validators/validateWithJoi.js
+++ b/src/lib/validators/validateWithJoi.js
@@ -7,8 +7,7 @@ const defaultOptions = Object.freeze({
 })
 
 module.exports = (schema, options = defaultOptions) => errorType => errorProps => value => {
-  const { value: validated, error } = schema.validate(value)
-
+  const { value: validated, error } = schema.validate(value, options)
   if (error) {
     throw new DVFError(
       errorType,


### PR DESCRIPTION
Requirement for https://app.asana.com/0/1165477653959782/1200108262675781/f

schemas validated using `validateWithJoi` were thought to be `required()` by default by it was not the case.