### PR TITLE
exposing getAuthenticated + custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.1 - 2021-09-04
+### Changed
+- Exposing `dvf.getAuthenticated` for arbitrary calls to GET endpoints
+- Allowing custom headers in `dvf.getAuthenticated`
+
 ## 2.1.0 - 2021-31-03
 ### Added
 - `dvf.getRegistrationStatuses` endpoint for checking both Deversifi and on-chain registration statuses - see `examples/29.getRegistrationStatuses.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -117,6 +117,7 @@ module.exports = () => {
   dvf.sign.nonceSignature = compose(require('../../api/sign/nonceSignature'))
 
   dvf.postAuthenticated = compose(require('../../lib/dvf/post-authenticated'))
+  dvf.getAuthenticated = compose(require('../../lib/dvf/get-authenticated'))
 
   dvf.createOrderPayload = compose(require('../../lib/dvf/createOrderPayload'))
   dvf.createMarketOrderPayload = compose(require('../../lib/dvf/createMarketOrderPayload'))

--- a/src/lib/dvf/get-authenticated.js
+++ b/src/lib/dvf/get-authenticated.js
@@ -1,9 +1,9 @@
 const getGeneric = require('./get-generic')
 const addAuthHeadersOrData = require('./addAuthHeadersOrData')
 
-module.exports = async (dvf, endpoint, nonce, signature, data = {}) => {
+module.exports = async (dvf, endpoint, nonce, signature, data = {}, headersOverride = {}) => {
   const { headers, data: qs } = await addAuthHeadersOrData(
     dvf, nonce, signature, { data }
   )
-  return getGeneric(dvf, endpoint, qs, headers)
+  return getGeneric(dvf, endpoint, qs, { ...headers, ...headersOverride })
 }


### PR DESCRIPTION
Related to https://app.asana.com/0/1165477653959782/1200151347471493/f

- Exposing `dvf.getAuthenticated` for arbitrary calls to GET endpoints
- Allowing custom headers in `dvf.getAuthenticated`