### PR TITLE
feat: optional meta field for register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.2 - 2021-16-04
+### Changed
+- `dvf.register` and `dvf.registerAndDeposit` to accept an optional `meta` parameter for interal use
+
 ## 2.1.1 - 2021-09-04
 ### Changed
 - Exposing `dvf.getAuthenticated` for arbitrary calls to GET endpoints

--- a/src/api/register.js
+++ b/src/api/register.js
@@ -3,7 +3,7 @@ const DVFError = require('../lib/dvf/DVFError')
 
 const validateAssertions = require('../lib/validators/validateAssertions')
 
-module.exports = async (dvf, starkPublicKey, nonce, signature, contractWalletAddress, encryptedTradingKey) => {
+module.exports = async (dvf, starkPublicKey, nonce, signature, contractWalletAddress, encryptedTradingKey, meta) => {
   validateAssertions(dvf, {starkPublicKey})
 
   const tradingKey = starkPublicKey.x
@@ -15,7 +15,8 @@ module.exports = async (dvf, starkPublicKey, nonce, signature, contractWalletAdd
     nonce,
     signature,
     ...(encryptedTradingKey && {encryptedTradingKey}),
-    ...(contractWalletAddress && {contractWalletAddress})
+    ...(contractWalletAddress && {contractWalletAddress}),
+    ...(meta && {meta})
   }
 
   const userRegistered = await post(dvf, endpoint, nonce, signature, data)

--- a/src/api/registerAndDeposit.js
+++ b/src/api/registerAndDeposit.js
@@ -17,7 +17,7 @@ const validateArg0 = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({
   context: 'depositV2'
 })
 
-module.exports = async (dvf, depositData, starkPublicKey, nonce, signature, contractWalletAddress, encryptedTradingKey) => {
+module.exports = async (dvf, depositData, starkPublicKey, nonce, signature, contractWalletAddress, encryptedTradingKey, meta) => {
 
   const starkKey = starkPublicKey.x
 
@@ -26,7 +26,8 @@ module.exports = async (dvf, depositData, starkPublicKey, nonce, signature, cont
     nonce,
     signature,
     ...(encryptedTradingKey && {encryptedTradingKey}),
-    ...(contractWalletAddress && {contractWalletAddress})
+    ...(contractWalletAddress && {contractWalletAddress}),
+    ...(meta && {meta})
   }
 
   const userRegistered = await post(dvf, '/v1/trading/w/register', nonce, signature, registrationData)


### PR DESCRIPTION
Related to : https://app.asana.com/0/1165477653959782/1200178777069035/f

- Adding optional `meta` field in `dvf.register` and `dvf.registerAndDeposit`