### PR TITLE
call validate endpoint inside v2 deposit function

### DIFF
--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -25,6 +25,7 @@ const validateArg0 = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({
 })
 
 const endpoint = '/v1/trading/deposits'
+const validationEndpoint = '/v1/trading/deposits-validate'
 
 module.exports = async (dvf, data, nonce, signature) => {
   const { token, amount, useProxiedContract, web3Options, permitParams } = validateArg0(data)
@@ -34,6 +35,8 @@ module.exports = async (dvf, data, nonce, signature) => {
   const tokenInfo = dvf.token.getTokenInfoOrThrow(token)
   const quantisedAmount = getSafeQuantizedAmountOrThrow(amount, tokenInfo)
   const vaultId = await getVaultId(dvf, token, nonce, signature)
+
+  await post(dvf, validationEndpoint, nonce, signature, { token, amount: quantisedAmount })
 
   if (!permitParams) {
     await dvf.contract.approve(


### PR DESCRIPTION
[Unexpected error when making deposits](https://app.asana.com/0/1165477653959782/1200425422177502)
**Issue**
Validations on `deposits` endpoint cannot revert an L1 transaction in flight, hence it'll only cause bad UX as users will see failure message for deposit however it will go through anyways

**Solution**
Transform into 2 part deposit by calling a validation endpoint to ensure upcoming deposit will be valid. This does not guarantee that all deposits will be correctly validated however we are not capable of validating if L1 transactions are submitted directly before calling this endpoint

Requires 3 part fix:

- [x] Backend (https://github.com/DeversiFi/launch-deversifi/pull/1410)
- Client (this)
- UI