### PR TITLE
Use auth header authentication for DepositV2

### DIFF
--- a/src/api/depositV2.js
+++ b/src/api/depositV2.js
@@ -37,6 +37,8 @@ module.exports = async (dvf, data, nonce, signature, txHashCb) => {
   const quantisedAmount = getSafeQuantizedAmountOrThrow(amount, tokenInfo)
   const vaultId = await getVaultId(dvf, token, nonce, signature)
 
+  // Force the use of header (instead of payload) for authentication.
+  dvf = FP.set('config.useAuthHeader', true, dvf)
   await post(dvf, validationEndpoint, nonce, signature, { token, amount: quantisedAmount })
 
   if (!permitParams) {
@@ -85,8 +87,6 @@ module.exports = async (dvf, data, nonce, signature, txHashCb) => {
     amount: quantisedAmount,
     txHash: transactionHash
   }
-  // Force the use of header (instead of payload) for authentication.
-  dvf = FP.set('config.useAuthHeader', true, dvf)
   const httpDeposit = await post(dvf, endpoint, nonce, signature, payload)
 
   const onChainDeposit = await onChainDepositPromise


### PR DESCRIPTION
Use auth header authentication for all of depositv2 requests

@benudall would you be able to pull this branch and test the example again? I'm unable to get any results from examples they seem to be hanging forever