### PR TITLE
[VEN-140] Governance: Incorrect behaviour when user try to unstake max value on Deversifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.8.3 - 2021-09-16
+### Changed
+- Update feeRate check on order payload creation to replace feeRate only if not present and preserve falsy values like 0 to allow staking
+
 ## 2.8.2 - 2021-08-02
 ### Changed
 - Bridged deposit to call deposit validation endpoint for sanity checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",

--- a/src/lib/dvf/createMarketOrderPayload.js
+++ b/src/lib/dvf/createMarketOrderPayload.js
@@ -44,7 +44,9 @@ module.exports = async (dvf, orderData) => {
 
   const finalValue = {
     ...value,
-    feeRate: value.feeRate || dvf.config.DVF.defaultFeeRate,
+    feeRate: [undefined, null].includes(value.feeRate)
+      ? dvf.config.DVF.defaultFeeRate
+      : value.feeRate,
     amount: prepareAmount(amountBN),
     price: value.worstCasePrice
   }

--- a/src/lib/dvf/createOrderPayload.js
+++ b/src/lib/dvf/createOrderPayload.js
@@ -34,7 +34,9 @@ module.exports = async (dvf, orderData) => {
   const { value, error } = schema.validate(orderData)
   // TODO: handle error
   // TODO: don't mutate
-  value.feeRate = value.feeRate || dvf.config.DVF.defaultFeeRate
+  value.feeRate = [undefined, null].includes(value.feeRate)
+    ? dvf.config.DVF.defaultFeeRate
+    : value.feeRate
   const ethAddress = orderData.ethAddress || dvf.get('account')
 
   return {


### PR DESCRIPTION
## 🧠  Description
- Update feeRate check on order payload creation to replace feeRate only if not present and preserve falsy values like 0 to allow staking

## 🕵🏻‍♂️  Task
>#### [[VEN-140] Governance: Incorrect behaviour when user try to unstake max value on Deversifi](https://darcs.atlassian.net/browse/VEN-140)

## 👯 Related
>#### https://github.com/DeversiFi/launch-deversifi/pull/1743
>#### https://github.com/DeversiFi/dvf-portal/pull/974