### PR TITLE
JUP-69: Bump eslint to 2020

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     BigInt: 'readonly'
   },
   parserOptions: {
-    ecmaVersion: 2018
+    ecmaVersion: 2020
   },
   rules: {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-client-js",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "src/dvf.js",
   "contributors": [
     "Henrique Matias <hems.inlet@gmail.com>",


### PR DESCRIPTION
Bumped to 2020 in [dvf-utils](https://github.com/DeversiFi/dvf-utils/pull/41), bumping here as well for consistency.