### PR TITLE
VEN-322 - Move wallet events to dvf-client-js

### DIFF
--- a/src/api/walletFailedEvent.js
+++ b/src/api/walletFailedEvent.js
@@ -1,0 +1,19 @@
+const { Joi } = require('dvf-utils')
+
+const postGeneric = require('../lib/dvf/post-generic')
+const validateWithJoi = require('../lib/validators/validateWithJoi')
+
+const schema = Joi.object({
+  walletType: Joi.string(),
+  errorText: Joi.string()
+})
+
+const validateData = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({
+  context: 'walletFailedEvent'
+})
+
+module.exports = async (dvf, data) => {
+  const endpoint = '/v1/trading/w/walletFailedEvent'
+  const { walletType, errorText } = validateData(data)
+  return postGeneric(dvf, endpoint, { walletType, errorText })
+}

--- a/src/api/walletSuccessEvent.js
+++ b/src/api/walletSuccessEvent.js
@@ -1,0 +1,19 @@
+const { Joi } = require('dvf-utils')
+
+const postGeneric = require('../lib/dvf/post-generic')
+const validateWithJoi = require('../lib/validators/validateWithJoi')
+
+const schema = Joi.object({
+  walletType: Joi.string(),
+  successText: Joi.string()
+})
+
+const validateData = validateWithJoi(schema)('INVALID_METHOD_ARGUMENT')({
+  context: 'walletSuccessEvent'
+})
+
+module.exports = async (dvf, data) => {
+  const endpoint = '/v1/trading/w/walletSuccessEvent'
+  const { walletType, successText } = validateData(data)
+  return postGeneric(dvf, endpoint, { walletType, successText })
+}

--- a/src/lib/dvf/bindApi.js
+++ b/src/lib/dvf/bindApi.js
@@ -226,6 +226,8 @@ module.exports = () => {
   dvf.poolTokensRate = compose(require('../../api/amm/poolTokensRate'))
   dvf.getRewardsLockedState = compose(require('../../api/amm/getRewardsLockedState'))
   dvf.postRewardsLockedState = compose(require('../../api/amm/postRewardsLockedState'))
+  dvf.walletFailedEvent = compose(require('../../api/walletFailedEvent'))
+  dvf.walletSuccessEvent = compose(require('../../api/walletSuccessEvent'))
 
   dvf.ledger = {
     deposit: compose(require('../../api/ledger/deposit')),

--- a/src/lib/dvf/post-authenticated.js
+++ b/src/lib/dvf/post-authenticated.js
@@ -1,21 +1,11 @@
-const { post } = require('request-promise')
 const _ = require('lodash')
 
 const addAuthHeadersOrData = require('./addAuthHeadersOrData')
+const postGeneric = require('./post-generic')
 
 module.exports = async (dvf, endpoint, nonce, signature, data = {}) => {
-  const url = dvf.config.api + endpoint
-
   const { headers, data: json } = await addAuthHeadersOrData(
     dvf, nonce, signature, { data }
   )
-
-  var options = {
-    uri: url,
-    headers,
-    // removes null and undefined values
-    json: _.omitBy(json, _.isNil)
-  }
-
-  return post(options)
+  return postGeneric(dvf, endpoint, json, headers)
 }

--- a/src/lib/dvf/post-generic.js
+++ b/src/lib/dvf/post-generic.js
@@ -1,0 +1,15 @@
+const { post } = require('request-promise')
+const _ = require('lodash')
+
+module.exports = async (dvf, endpoint, json = {}, headers = {}) => {
+  const url = dvf.config.api + endpoint
+
+  const options = {
+    uri: url,
+    headers,
+    // removes null and undefined values
+    json: _.omitBy(json, _.isNil)
+  }
+
+  return post(options)
+}


### PR DESCRIPTION
https://darcs.atlassian.net/browse/VEN-322

* Move `walletFailedEvent` and `walletSuccessEvent` endpoints to `dvf-client-js`
* Refactor `post` code and use it in the endpoints above