### PR TITLE
fix: tests by adding dummy address to keep the argument sequence right

### DIFF
--- a/src/api/getWithdrawals.test.js
+++ b/src/api/getWithdrawals.test.js
@@ -56,6 +56,7 @@ describe('dvf.getWithdrawals', () => {
     const nonce = Date.now() / 1000 + ''
     const signature = await dvf.sign(nonce.toString(16))
     const token = 'ETH'
+    const address = '0x49e4d1e2aa7d026188251392dd2d335c176d846d8a894a8092c835f3b345e2ad'
 
     const apiResponse = [
       {
@@ -85,7 +86,7 @@ describe('dvf.getWithdrawals', () => {
       .post('/v1/trading/r/getPendingWithdrawals', payloadValidator)
       .reply(200, apiResponse)
 
-    const result = await dvf.getWithdrawals(token, nonce, signature)
+    const result = await dvf.getWithdrawals(token, address, nonce, signature)
 
     expect(payloadValidator).toBeCalled()
     expect(result).toEqual(apiResponse)


### PR DESCRIPTION
getWithdrawals.test.js tests are failing since the `address` is not passed to the `dvf.getWithdrawals` function. 